### PR TITLE
Improve drafts UI

### DIFF
--- a/js/src/forum/addDraftsDropdown.js
+++ b/js/src/forum/addDraftsDropdown.js
@@ -15,13 +15,9 @@ import HeaderSecondary from 'flarum/components/HeaderSecondary';
 import DraftsDropdown from './components/DraftsDropdown';
 
 export default function() {
-    extend(HeaderSecondary.prototype, 'items', function(items) {
-        if (!app.session.user) return;
-        if (
-            (app.session.user.drafts() && app.session.user.drafts().length && !app.cache.drafts) ||
-            (app.cache.drafts && app.cache.drafts.length !== 0)
-        ) {
-            items.add('Drafts', <DraftsDropdown />, 20);
-        }
+    extend(HeaderSecondary.prototype, 'items', function (items) {
+        if (!app.session.user || !app.forum.attribute('canSaveDrafts')) return;
+
+        items.add('Drafts', <DraftsDropdown />, 20);
     });
 }

--- a/js/src/forum/components/DraftsDropdown.js
+++ b/js/src/forum/components/DraftsDropdown.js
@@ -35,13 +35,13 @@ export default class DraftsDropdown extends NotificationsDropdown {
         if (app.cache.drafts) {
             return app.cache.drafts.length;
         }
-        return app.session.user.drafts().length;
+        return app.session.user.draftCount();
     }
 
     getNewCount() {
         if (app.cache.drafts) {
             return app.cache.drafts.length;
         }
-        return app.session.user.drafts().length;
+        return app.session.user.draftCount();
     }
 }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -8,7 +8,7 @@ fof-drafts:
       alert: Draft saved.
       exit_alert: Discard changes to draft?
     dropdown:
-      empty_text: You didn't save any drafts
+      empty_text: You haven't saved any drafts
       title: Drafts
       button: Delete Draft
       tooltip: => fof-drafts.forum.dropdown.title

--- a/src/Listeners/AddApiAttributes.php
+++ b/src/Listeners/AddApiAttributes.php
@@ -12,8 +12,10 @@
 namespace FoF\Drafts\Listeners;
 
 use Flarum\Api\Event\Serializing;
+use Flarum\Api\Serializer\CurrentUserSerializer;
 use Flarum\Api\Serializer\ForumSerializer;
 use Flarum\Settings\SettingsRepositoryInterface;
+use FoF\Drafts\Draft;
 
 class AddApiAttributes
 {
@@ -34,6 +36,10 @@ class AddApiAttributes
     {
         if ($event->isSerializer(ForumSerializer::class)) {
             $event->attributes['canSaveDrafts'] = $event->actor->hasPermissionLike('user.saveDrafts');
+        }
+
+        if ($event->isSerializer(CurrentUserSerializer::class)) {
+            $event->attributes['draftCount'] = (int) Draft::where('user_id', $event->actor->id)->count();
         }
     }
 }


### PR DESCRIPTION
Fixes #5 

Improve UI of using drafts:

- Load drafts list when opening the composer; this way, we avoid a situation where a new draft is being saved, no drafts have been loaded, and the user is presented with an empty draft list in the header.
- Load draft count on page load separately from the draft list itself: this means that the count is always accurate.
- Don't close the composer when saving drafts; this is behavior not used in any other product (imagine if Microsoft Word shut down whenever you pressed save).
- When a new draft is created, save it as the composer component's stored draft, so that future saves will be treated as updates
- Prevent duplicate save messages; ensure that the save message disappears and reappears when updating a draft so that the user clearly sees that the change was successsful, and not a left-over save message
- Right now, the drafts dropdown is only shown if there are already cached drafts saved. However, this doesn't really work, since drafts aren't downloaded by default. Now, the dropdown button will always be shown, and the list of drafts will be loaded by clicking on it, as always.