### PR TITLE
Add full support for reply, byobu composers

### DIFF
--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -42,55 +42,60 @@ export default class DraftsList extends Component {
                     <ul className="NotificationGroup-content">
                         {drafts.length
                             ? drafts
-                                .sort((a, b) => b.updatedAt() - a.updatedAt())
-                                .map((draft) => {
-                                    return (
-                                        <li>
-                                            <a onclick={this.showComposer.bind(this, draft)} className="Notification draft--item">
-                                                {avatar(draft.user())}
-                                                {icon(draft.icon(), { className: 'Notification-icon' })}
-                                                <span className="Notification-content">
-                                                    {draft.type() === 'reply' ? draft.loadRelationships().discussion.title() : draft.title()}
-                                                </span>
-                                                {humanTime(draft.updatedAt())}
-                                                {Button.component({
-                                                    icon: 'fas fa-times',
-                                                    style: 'float: right; z-index: 20;',
-                                                    className: 'Button Button--icon Button--link draft--delete draft--delete',
-                                                    title: app.translator.trans('fof-drafts.forum.dropdown.delete_button'),
-                                                    onclick: (e) => {
-                                                        this.deleteDraft(draft);
-                                                        e.stopPropagation();
-                                                    },
-                                                })}
-                                                {app.forum.attribute('canScheduleDrafts') && app.forum.attribute('drafts.enableScheduledDrafts')
-                                                    ? Button.component({
-                                                        icon: draft.scheduledValidationError()
-                                                            ? 'fas fa-calendar-times'
-                                                            : draft.scheduledFor()
+                                  .sort((a, b) => b.updatedAt() - a.updatedAt())
+                                  .map((draft) => {
+                                      return (
+                                          <li>
+                                              <a onclick={this.showComposer.bind(this, draft)} className="Notification draft--item">
+                                                  {avatar(draft.user())}
+                                                  {icon(draft.icon(), { className: 'Notification-icon' })}
+                                                  <span className="Notification-content">
+                                                      {draft.type() === 'reply' ? draft.loadRelationships().discussion.title() : draft.title()}
+                                                  </span>
+                                                  {humanTime(draft.updatedAt())}
+                                                  {Button.component({
+                                                      icon: 'fas fa-times',
+                                                      style: 'float: right; z-index: 20;',
+                                                      className: 'Button Button--icon Button--link draft--delete draft--delete',
+                                                      title: app.translator.trans('fof-drafts.forum.dropdown.delete_button'),
+                                                      onclick: (e) => {
+                                                          this.deleteDraft(draft);
+                                                          e.stopPropagation();
+                                                      },
+                                                  })}
+                                                  {app.forum.attribute('canScheduleDrafts') && app.forum.attribute('drafts.enableScheduledDrafts')
+                                                      ? Button.component({
+                                                            icon: draft.scheduledValidationError()
+                                                                ? 'fas fa-calendar-times'
+                                                                : draft.scheduledFor()
                                                                 ? 'fas fa-calendar-check'
                                                                 : 'fas fa-calendar-plus',
-                                                        style: 'float: right; z-index: 20;',
-                                                        className: 'Button Button--icon Button--link draft--schedule',
-                                                        title: app.translator.trans('fof-drafts.forum.dropdown.schedule_button'),
-                                                        onclick: (e) => {
-                                                            this.scheduleDraft(draft);
-                                                            e.stopPropagation();
-                                                        },
-                                                    }) : ''}
-                                                <div className="Notification-excerpt">{truncate(draft.content(), 200)}</div>
-                                                {draft.scheduledValidationError() ? <p className="scheduledValidationError">{draft.scheduledValidationError()}</p> : ''}
-                                            </a>
-                                        </li>
-                                    );
-                                })
+                                                            style: 'float: right; z-index: 20;',
+                                                            className: 'Button Button--icon Button--link draft--schedule',
+                                                            title: app.translator.trans('fof-drafts.forum.dropdown.schedule_button'),
+                                                            onclick: (e) => {
+                                                                this.scheduleDraft(draft);
+                                                                e.stopPropagation();
+                                                            },
+                                                        })
+                                                      : ''}
+                                                  <div className="Notification-excerpt">{truncate(draft.content(), 200)}</div>
+                                                  {draft.scheduledValidationError() ? (
+                                                      <p className="scheduledValidationError">{draft.scheduledValidationError()}</p>
+                                                  ) : (
+                                                      ''
+                                                  )}
+                                              </a>
+                                          </li>
+                                      );
+                                  })
                             : ''}
 
                         {this.loading
                             ? LoadingIndicator.component({ className: 'LoadingIndicator--block' })
                             : !drafts.length && (
-                                <div className="NotificationList-empty">{app.translator.trans('fof-drafts.forum.dropdown.empty_text')}</div>
-                            )}
+                                  <div className="NotificationList-empty">{app.translator.trans('fof-drafts.forum.dropdown.empty_text')}</div>
+                              )}
                     </ul>
                 </div>
             </div>
@@ -158,7 +163,7 @@ export default class DraftsList extends Component {
             .find('drafts')
             .then(
                 () => (app.cache.draftsLoaded = true),
-                () => { }
+                () => {}
             )
             .then(() => {
                 this.loading = false;

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -108,6 +108,7 @@ export default class DraftsList extends Component {
             }
 
             this.loading = false;
+            m.redraw();
         });
     }
 

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -48,7 +48,7 @@ export default class DraftsList extends Component {
                                         <li>
                                             <a onclick={this.showComposer.bind(this, draft)} className="Notification draft--item">
                                                 {avatar(draft.user())}
-                                                {icon('fas fa-edit', { className: 'Notification-icon' })}
+                                                {icon(draft.icon(), { className: 'Notification-icon' })}
                                                 <span className="Notification-content">
                                                     {draft.type() === 'reply' ? draft.loadRelationships().discussion.title() : draft.title()}
                                                 </span>

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -126,7 +126,7 @@ export default class DraftsList extends Component {
 
         switch (draft.type()) {
             case 'privateDiscussion':
-                componentClass = require('@fof-byobu').compat['components/PrivateDiscussionComposer'];
+                componentClass = require('@fof-byobu').components['PrivateDiscussionComposer'];
                 break;
             case 'reply':
                 componentClass = ReplyComposer;

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -18,6 +18,7 @@ import addDraftsDropdown from './addDraftsDropdown';
 import addPreferences from './addPreferences';
 import Composer from 'flarum/components/Composer';
 import DiscussionComposer from 'flarum/components/DiscussionComposer';
+import ReplyComposer from 'flarum/components/ReplyComposer';
 import Button from 'flarum/components/Button';
 import DraftsList from './components/DraftsList';
 import fillRelationship from './utils/fillRelationship';
@@ -128,7 +129,7 @@ app.initializers.add('fof-drafts', () => {
 
     extend(Composer.prototype, 'controlItems', function (items) {
         if (
-            !(this.component instanceof DiscussionComposer) ||
+            !(this.component instanceof DiscussionComposer || this.component instanceof ReplyComposer) ||
             !app.forum.attribute('canSaveDrafts') ||
             this.position === Composer.PositionEnum.MINIMIZED
         )
@@ -196,21 +197,27 @@ app.initializers.add('fof-drafts', () => {
         return prevented;
     });
 
-    extend(DiscussionComposer.prototype, 'init', function () {
-        Object.keys(this.props).forEach((key) => {
+    function initComposerBody() {
+        Object.keys(this.props).forEach(key => {
             if (!['originalContent', 'title', 'user'].includes(key)) {
                 this[key] = this.props[key];
             } else if (key === 'title') {
                 this.title = m.prop(this.props.title);
             }
         });
-    });
+    }
 
-    extend(DiscussionComposer.prototype, 'onsubmit', function () {
+    extend(DiscussionComposer.prototype, 'init', initComposerBody);
+    extend(ReplyComposer.prototype, 'init', initComposerBody);
+
+    function deleteDraftsOnSubmit() {
         if (this.draft) {
             this.draft.delete();
         }
-    });
+    }
+
+    extend(DiscussionComposer.prototype, 'onsubmit', deleteDraftsOnSubmit);
+    extend(ReplyComposer.prototype, 'onsubmit', deleteDraftsOnSubmit);
 
     addDraftsDropdown();
     addPreferences();

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -50,7 +50,7 @@ app.initializers.add('fof-drafts', () => {
                     return true;
                 }
             } else {
-                if (getData(field) != draft[field]()) {
+                if (getData(field) != draft.data.attributes[field]) {
                     return true;
                 }
             }

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -198,7 +198,7 @@ app.initializers.add('fof-drafts', () => {
     });
 
     function initComposerBody() {
-        Object.keys(this.props).forEach(key => {
+        Object.keys(this.props).forEach((key) => {
             if (!['originalContent', 'title', 'user'].includes(key)) {
                 this[key] = this.props[key];
             } else if (key === 'title') {

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -159,7 +159,7 @@ app.initializers.add('fof-drafts', () => {
         );
     });
 
-    extend(Composer.prototype, 'init', function () {
+    extend(Composer.prototype, 'show', function () {
         if (!app.forum.attribute('canSaveDrafts')) return;
 
         if (app.session.user.preferences().draftAutosaveEnable) {

--- a/js/src/forum/models/Draft.js
+++ b/js/src/forum/models/Draft.js
@@ -67,10 +67,10 @@ export default class Draft extends mixin(Model, {
                 const recipients = new ItemList();
 
                 (this.loadedRelationships['recipientUsers'] || []).forEach((user) => {
-                    recipients.add('users:' + user.id(), user);
+                    if (user) recipients.add('users:' + user.id(), user);
                 });
                 (this.loadedRelationships['recipienGroups'] || []).forEach((group) => {
-                    recipients.add('groups:' + group.id(), group);
+                    if (group) recipients.add('groups:' + group.id(), group);
                 });
 
                 this.loadedRelationships['recipients'] = recipients;

--- a/js/src/forum/models/Draft.js
+++ b/js/src/forum/models/Draft.js
@@ -9,7 +9,7 @@
  *
  */
 import Model from 'flarum/Model';
-import ItemList from "flarum/utils/ItemList";
+import ItemList from 'flarum/utils/ItemList';
 import mixin from 'flarum/utils/mixin';
 
 export default class Draft extends mixin(Model, {
@@ -50,7 +50,7 @@ export default class Draft extends mixin(Model, {
             const relationships = this.relationships();
 
             if (relationships) {
-                Object.keys(relationships).forEach(relationshipName => {
+                Object.keys(relationships).forEach((relationshipName) => {
                     const relationship = relationships[relationshipName];
                     let relationshipData;
                     if (Array.isArray(relationship.data)) {
@@ -64,14 +64,14 @@ export default class Draft extends mixin(Model, {
             }
 
             if ('recipientUsers' in this.loadedRelationships || 'recipientGroups' in this.loadedRelationships) {
-                const recipients = new ItemList;
+                const recipients = new ItemList();
 
-                (this.loadedRelationships['recipientUsers'] || []).forEach(user => {
-                    recipients.add("users:" + user.id(), user);
+                (this.loadedRelationships['recipientUsers'] || []).forEach((user) => {
+                    recipients.add('users:' + user.id(), user);
                 });
-                (this.loadedRelationships['recipienGroups'] || []).forEach(group => {
-                    recipients.add("groups:" + group.id(), group);
-                })
+                (this.loadedRelationships['recipienGroups'] || []).forEach((group) => {
+                    recipients.add('groups:' + group.id(), group);
+                });
 
                 this.loadedRelationships['recipients'] = recipients;
             }
@@ -92,5 +92,5 @@ export default class Draft extends mixin(Model, {
         Object.assign(data, this.loadRelationships());
 
         return data;
-    }
-}) { }
+    },
+}) {}

--- a/js/src/forum/models/Draft.js
+++ b/js/src/forum/models/Draft.js
@@ -9,6 +9,7 @@
  *
  */
 import Model from 'flarum/Model';
+import ItemList from "flarum/utils/ItemList";
 import mixin from 'flarum/utils/mixin';
 
 export default class Draft extends mixin(Model, {
@@ -19,4 +20,77 @@ export default class Draft extends mixin(Model, {
     relationships: Model.attribute('relationships'),
     scheduledFor: Model.attribute('scheduledFor', Model.transformDate),
     updatedAt: Model.attribute('updatedAt', Model.transformDate),
-}) {}
+
+    type() {
+        const relationships = this.loadRelationships();
+        if ('discussion' in relationships) {
+            return 'reply';
+        } else if (app.initializers.has('fof-byobu') && ('recipientGroups' in relationships || 'recipientUsers' in relationships)) {
+            return 'privateDiscussion';
+        } else {
+            return 'discussion';
+        }
+    },
+
+    icon() {
+        switch (this.type()) {
+            case 'discussion':
+                return 'fas fa-edit';
+            case 'reply':
+                return 'fas fa-reply';
+            case 'privateDiscussion':
+                return 'fas fa-eye-slash';
+        }
+    },
+
+    loadRelationships() {
+        if (!this.loadedRelationships) {
+            this.loadedRelationships = {};
+
+            const relationships = this.relationships();
+
+            if (relationships) {
+                Object.keys(relationships).forEach(relationshipName => {
+                    const relationship = relationships[relationshipName];
+                    let relationshipData;
+                    if (Array.isArray(relationship.data)) {
+                        relationshipData = relationship.data.map((model, i) => app.store.getById(model.type, model.id));
+                    } else {
+                        relationshipData = app.store.getById(relationship.data.type, relationship.data.id);
+                    }
+
+                    this.loadedRelationships[relationshipName] = relationshipData;
+                });
+            }
+
+            if ('recipientUsers' in this.loadedRelationships || 'recipientGroups' in this.loadedRelationships) {
+                const recipients = new ItemList;
+
+                (this.loadedRelationships['recipientUsers'] || []).forEach(user => {
+                    recipients.add("users:" + user.id(), user);
+                });
+                (this.loadedRelationships['recipienGroups'] || []).forEach(group => {
+                    recipients.add("groups:" + group.id(), group);
+                })
+
+                this.loadedRelationships['recipients'] = recipients;
+            }
+        }
+
+        return this.loadedRelationships;
+    },
+
+    compileData() {
+        const data = {
+            originalContent: this.content(),
+            title: this.title(),
+            user: app.session.user,
+            confirmExit: app.translator.trans('fof-drafts.forum.composer.exit_alert'),
+            draft: this,
+        };
+
+        Object.assign(data, this.loadRelationships());
+
+        return data;
+    }
+}) { }

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,3 +1,3 @@
 module.exports = require('flarum-webpack-config')({
-    useExtensions: ['fof-components']
+    useExtensions: ['fof-byobu', 'fof-components']
 });


### PR DESCRIPTION
Depends on https://github.com/FriendsOfFlarum/byobu/pull/112

Fixes #1 

**Reviewers should focus on:**
To get the byobu integration to work, I needed to import the PrivateDiscussionComposer from byobu. I got it to work (via https://github.com/FriendsOfFlarum/byobu/pull/112), but this is probably not a very elegant/correct way of accomplishing this. 

**Changes:**
- Add full support for discussion reply, byobu composers. Each now has a different icon in the drafts list
- Byobu drafts default to a regular discussion is byobu is disabled. Does not crash :grinning: 