### PR TITLE
Load only when possible

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -81,6 +81,7 @@ app.initializers.add('fof-drafts', () => {
     });
 
     extend(Composer.prototype, 'init', function () {
+        if (!app.forum.attribute('canSaveDrafts')) return;
         // Load drafts; if already loaded, this will not do anything.
         const draftsList = new DraftsList();
         draftsList.load();


### PR DESCRIPTION
It fixes "You do not have permission to do that." for unauthorized users such as guests