### PR TITLE
Drafts deletion UX improvements

### DIFF
--- a/js/src/forum/addPreferences.js
+++ b/js/src/forum/addPreferences.js
@@ -35,7 +35,7 @@ export default function () {
         );
 
         items.add('draft-autosave-interval',
-                <label>
+            this.user.preferences().draftAutosaveEnable ? <label>
                     <p>{app.translator.trans('fof-drafts.forum.user.settings.draft_autosave_interval_label')}</p>
                     <input
                         className="FormControl"
@@ -62,7 +62,7 @@ export default function () {
                     {this.draftAutosaveIntervalInvalid ? <p class="invalidInterval">
                         <small>{app.translator.trans('fof-drafts.forum.user.settings.draft_autosave_interval_invalid')}</small>
                     </p> : ''}
-                </label>
+                </label>: ''
         );
 
         return items;

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -96,7 +96,7 @@ export default class DraftsList extends Component {
         if (!window.confirm(app.translator.trans('fof-drafts.forum.dropdown.alert'))) return;
 
         draft.delete().then(() => {
-            if (app.composer.component && app.composer.component.draft.id() === draft.id()) {
+            if (app.composer.component && app.composer.component.draft.id() === draft.id() && !app.composer.changed()) {
                 app.composer.hide();
             }
 

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -58,7 +58,10 @@ export default class DraftsList extends Component {
                                                     style: 'float: right; z-index: 20;',
                                                     className: 'Button Button--icon Button--link draft--delete',
                                                     title: app.translator.trans('fof-drafts.forum.dropdown.delete_button'),
-                                                    onclick: this.deleteDraft.bind(this, draft),
+                                                    onclick: e => {
+                                                        this.deleteDraft(draft);
+                                                        e.stopPropagation();
+                                                    },
                                                 })}
                                                 {app.forum.attribute('canScheduleDrafts') && app.forum.attribute('drafts.enableScheduledDrafts') ? Button.component({
                                                     icon: draft.scheduledValidationError() ? 'fas fa-calendar-times' : draft.scheduledFor() ? 'fas fa-calendar-check' : 'fas fa-calendar-plus',
@@ -92,15 +95,13 @@ export default class DraftsList extends Component {
 
         if (!window.confirm(app.translator.trans('fof-drafts.forum.dropdown.alert'))) return;
 
-        draft.delete();
-        app.cache.drafts.some((cacheDraft, i) => {
-            if (cacheDraft.id() === draft.id()) {
-                app.cache.drafts.splice(i, 1);
+        draft.delete().then(() => {
+            if (app.composer.component && app.composer.component.draft.id() === draft.id()) {
+                app.composer.hide();
             }
-        });
-        app.composer.hide();
 
-        this.loading = false;
+            this.loading = false;
+        });
     }
 
     scheduleDraft(draft) {

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -188,7 +188,18 @@ app.initializers.add('fof-drafts', () => {
         if (this.autosaveInterval) clearInterval(this.autosaveInterval);
     });
 
-    extend(DiscussionComposer.prototype, 'init', function () {
+    extend(Composer.prototype, 'preventExit', function (prevented) {
+        if (prevented || !this.component) return;
+
+        const draft = this.component.draft;
+        if (!draft.title() && !draft.content() && confirm(app.translator.trans('fof-drafts.forum.composer.discard_empty_draft_alert'))) {
+            draft.delete();
+        }
+
+        return prevented;
+    })
+
+    extend(DiscussionComposer.prototype, 'init', function() {
         Object.keys(this.props).forEach(key => {
             if (!['originalContent', 'title', 'user'].includes(key)) {
                 this[key] = this.props[key];

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -189,6 +189,10 @@ app.initializers.add('fof-drafts', () => {
     });
 
     override(Composer.prototype, 'preventExit', function (original) {
+        if (this.component && this.component.draft) {
+            this.component.props.confirmExit = app.translator.trans('fof-drafts.forum.composer.exit_alert');
+        }
+
         let prevented = false;
         if (this.changed()) {
             prevented = original();
@@ -196,7 +200,7 @@ app.initializers.add('fof-drafts', () => {
 
         if (prevented) return prevented;
 
-        if (!this.component) return false;
+        if (!this.component) return;
 
         const draft = this.component.draft;
         if (draft && !draft.title() && !draft.content() && confirm(app.translator.trans('fof-drafts.forum.composer.discard_empty_draft_alert'))) {

--- a/js/src/forum/models/Draft.js
+++ b/js/src/forum/models/Draft.js
@@ -19,4 +19,15 @@ export default class Draft extends mixin(Model, {
     relationships: Model.attribute('relationships'),
     scheduledFor: Model.attribute('scheduledFor', Model.transformDate),
     updatedAt: Model.attribute('updatedAt', Model.transformDate),
-}) {}
+}) {
+    delete() {
+        return super.delete().then(() => {
+            app.cache.drafts.some((cacheDraft, i) => {
+                if (cacheDraft.id() === this.id()) {
+                    app.cache.drafts.splice(i, 1);
+                }
+            });
+            m.redraw();
+        });
+    }
+}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -18,7 +18,8 @@ fof-drafts:
     dropdown:
       empty_text: You haven't saved any drafts
       title: Drafts
-      button: Delete Draft
+      delete_button: Delete Draft
+      schedule_button: Schedule Draft
       tooltip: => fof-drafts.forum.dropdown.title
       alert: Are you sure you want to delete your draft?
     schedule_draft_modal:

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -14,6 +14,7 @@ fof-drafts:
       saving: Saving...
       saved: Saved!
       exit_alert: Discard changes to draft?
+      discard_empty_draft_alert: Discard empty draft?
     dropdown:
       empty_text: You haven't saved any drafts
       title: Drafts


### PR DESCRIPTION
- When deleting a draft, don't open it (caused by nested <a>/button, fixed by e.stopPropogation)
- When deleting a draft, only close the composer if that draft is currently open.
- When closing the composer, if the current draft is empty, open an alert offering to discard it (fixes #14)
- Move draft deletion logic into Draft model so it can be reused, use the returned promise instead of synchronous operations

After #9, the changed method will be available. At that point, I will follow up with another PR adding:

- When deleting a draft, only close the composer if that draft is currently open **and has not been changed**
- Don't show the "discard changes to draft" confirmation alert if there are no changes.