### PR TITLE
Add scheduled drafts feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "license": "MIT",
     "require": {
         "flarum/core": "^0.1.0-beta.8",
-        "fof/console": "^0.5"
+        "fof/console": "^0.5",
+        "fof/components": ">=0.1.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "type": "flarum-extension",
     "license": "MIT",
     "require": {
-        "flarum/core": "^0.1.0-beta.8"
+        "flarum/core": "^0.1.0-beta.8",
+        "fof/console": "^0.5"
     },
     "authors": [
         {

--- a/extend.php
+++ b/extend.php
@@ -18,6 +18,7 @@ use FoF\Drafts\Api\Controller;
 use Illuminate\Contracts\Events\Dispatcher;
 
 return [
+    new \FoF\Components\Extend\AddFofComponents(),
     new \FoF\Console\Extend\EnableConsole(),
 
     (new Extend\Frontend('forum'))
@@ -42,6 +43,7 @@ return [
         $events->listen(Serializing::class, Listeners\AddApiAttributes::class);
 
         $events->subscribe(Listeners\AddRelationships::class);
+        $events->subscribe(Listeners\AddSettings::class);
 
         $app->register(Providers\ConsoleProvider::class);
     },

--- a/extend.php
+++ b/extend.php
@@ -12,14 +12,13 @@
 namespace FoF\Drafts;
 
 use Flarum\Api\Event\Serializing;
-use Flarum\Console\Event\Configuring;
-use Flarum\Foundation\Application;
 use Flarum\Extend;
+use Flarum\Foundation\Application;
 use FoF\Drafts\Api\Controller;
 use Illuminate\Contracts\Events\Dispatcher;
 
 return [
-    new \FoF\Console\Extend\EnableConsole,
+    new \FoF\Console\Extend\EnableConsole(),
 
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
@@ -37,7 +36,7 @@ return [
 
     new Extend\Locales(__DIR__.'/resources/locale'),
 
-    (new Extend\Console)->command(Console\PublishDrafts::class),
+    (new Extend\Console())->command(Console\PublishDrafts::class),
 
     function (Application $app, Dispatcher $events) {
         $events->listen(Serializing::class, Listeners\AddApiAttributes::class);

--- a/extend.php
+++ b/extend.php
@@ -12,11 +12,15 @@
 namespace FoF\Drafts;
 
 use Flarum\Api\Event\Serializing;
+use Flarum\Console\Event\Configuring;
+use Flarum\Foundation\Application;
 use Flarum\Extend;
 use FoF\Drafts\Api\Controller;
 use Illuminate\Contracts\Events\Dispatcher;
 
 return [
+    new \FoF\Console\Extend\EnableConsole,
+
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
         ->css(__DIR__.'/resources/less/forum.less')
@@ -33,9 +37,13 @@ return [
 
     new Extend\Locales(__DIR__.'/resources/locale'),
 
-    function (Dispatcher $events) {
+    (new Extend\Console)->command(Console\PublishDrafts::class),
+
+    function (Application $app, Dispatcher $events) {
         $events->listen(Serializing::class, Listeners\AddApiAttributes::class);
 
         $events->subscribe(Listeners\AddRelationships::class);
+
+        $app->register(Providers\ConsoleProvider::class);
     },
 ];

--- a/js/package.json
+++ b/js/package.json
@@ -2,10 +2,11 @@
   "name": "@fof/drafts",
   "version": "0.0.0",
   "dependencies": {
-    "fclone": "^1.0.11",
+    "dayjs": "^1.8",
     "flarum-webpack-config": "^0.1.0-beta.8",
-    "webpack": "^4.0.0",
-    "webpack-cli": "^3.0.7"
+    "flatpickr": "^4",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.11"
   },
   "scripts": {
     "build": "webpack --mode production",
@@ -13,6 +14,6 @@
     "lint": "prettier --single-quote --trailing-comma es5 --print-width 150 --tab-width 4 --write 'src/**/*'"
   },
   "devDependencies": {
-    "prettier": "^1.15.2"
+    "prettier": "^1.19.1"
   }
 }

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -14,11 +14,23 @@ import { extend } from 'flarum/extend';
 import PermissionGrid from 'flarum/components/PermissionGrid';
 
 app.initializers.add('fof-drafts', app => {
+    extend(app, 'getRequiredPermissions', function (required, permission) {
+        if (permission === 'user.scheduleDrafts') {
+            required.push('user.saveDrafts');
+        }
+    });
+
     extend(PermissionGrid.prototype, 'startItems', items => {
         items.add('fof-draft-create', {
             icon: 'fa fa-edit',
             label: app.translator.trans('fof-drafts.admin.permissions.start'),
             permission: 'user.saveDrafts',
+        });
+
+        items.add('fof-draft-schedule', {
+            icon: 'fas fa-calendar-plus',
+            label: app.translator.trans('fof-drafts.admin.permissions.schedule'),
+            permission: 'user.scheduleDrafts',
         });
     });
 });

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -12,8 +12,27 @@
 import app from 'flarum/app';
 import { extend } from 'flarum/extend';
 import PermissionGrid from 'flarum/components/PermissionGrid';
+import { settings } from '@fof-components';
+
+const {
+    SettingsModal,
+    items: { BooleanItem },
+} = settings;
 
 app.initializers.add('fof-drafts', app => {
+    app.extensionSettings['fof-drafts'] = () =>
+        app.modal.show(
+            new SettingsModal({
+                title: app.translator.trans('fof-drafts.admin.settings.title'),
+                type: 'small',
+                items: [
+                    <BooleanItem key="fof-drafts.enable_scheduled_drafts">
+                        {app.translator.trans('fof-drafts.admin.settings.enable_scheduled_drafts')}
+                    </BooleanItem>,
+                ],
+            })
+        );
+
     extend(app, 'getRequiredPermissions', function (required, permission) {
         if (permission === 'user.scheduleDrafts') {
             required.push('user.saveDrafts');

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -60,7 +60,7 @@ export default class DraftsList extends Component {
                                                     title: app.translator.trans('fof-drafts.forum.dropdown.delete_button'),
                                                     onclick: this.deleteDraft.bind(this, draft),
                                                 })}
-                                                {Button.component({
+                                                {app.forum.attribute('canScheduleDrafts') ? Button.component({
                                                     icon: draft.scheduledFor() ? 'fas fa-calendar-check' : 'fas fa-calendar-plus',
                                                     style: 'float: right; z-index: 20;',
                                                     className: 'Button Button--icon Button--link draft--schedule',
@@ -69,7 +69,7 @@ export default class DraftsList extends Component {
                                                         this.scheduleDraft(draft);
                                                         e.stopPropagation();
                                                     },
-                                                })}
+                                                }) : ''}
                                                 <div className="Notification-excerpt">{truncate(draft.content(), 200)}</div>
                                             </a>
                                         </li>
@@ -103,6 +103,8 @@ export default class DraftsList extends Component {
     }
 
     scheduleDraft(draft) {
+        if (!app.forum.attribute('canScheduleDrafts')) return;
+
         app.modal.show(new ScheduleDraftModal({draft}));
     }
 

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -61,7 +61,7 @@ export default class DraftsList extends Component {
                                                     onclick: this.deleteDraft.bind(this, draft),
                                                 })}
                                                 {app.forum.attribute('canScheduleDrafts') ? Button.component({
-                                                    icon: draft.scheduledFor() ? 'fas fa-calendar-check' : 'fas fa-calendar-plus',
+                                                    icon: draft.scheduledValidationError() ? 'fas fa-calendar-times' : draft.scheduledFor() ? 'fas fa-calendar-check' : 'fas fa-calendar-plus',
                                                     style: 'float: right; z-index: 20;',
                                                     className: 'Button Button--icon Button--link draft--schedule',
                                                     title: app.translator.trans('fof-drafts.forum.dropdown.schedule_button'),
@@ -71,6 +71,7 @@ export default class DraftsList extends Component {
                                                     },
                                                 }) : ''}
                                                 <div className="Notification-excerpt">{truncate(draft.content(), 200)}</div>
+                                                {draft.scheduledValidationError() ? <p className="scheduledValidationError">{draft.scheduledValidationError()}</p> : ''}
                                             </a>
                                         </li>
                                     );

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -60,7 +60,7 @@ export default class DraftsList extends Component {
                                                     title: app.translator.trans('fof-drafts.forum.dropdown.delete_button'),
                                                     onclick: this.deleteDraft.bind(this, draft),
                                                 })}
-                                                {app.forum.attribute('canScheduleDrafts') ? Button.component({
+                                                {app.forum.attribute('canScheduleDrafts') && app.forum.attribute('drafts.enableScheduledDrafts') ? Button.component({
                                                     icon: draft.scheduledValidationError() ? 'fas fa-calendar-times' : draft.scheduledFor() ? 'fas fa-calendar-check' : 'fas fa-calendar-plus',
                                                     style: 'float: right; z-index: 20;',
                                                     className: 'Button Button--icon Button--link draft--schedule',
@@ -104,7 +104,7 @@ export default class DraftsList extends Component {
     }
 
     scheduleDraft(draft) {
-        if (!app.forum.attribute('canScheduleDrafts')) return;
+        if (!app.forum.attribute('canScheduleDrafts') || !app.forum.attribute('drafts.enableScheduledDrafts')) return;
 
         app.modal.show(new ScheduleDraftModal({draft}));
     }

--- a/js/src/forum/components/DraftsList.js
+++ b/js/src/forum/components/DraftsList.js
@@ -17,6 +17,7 @@ import icon from 'flarum/helpers/icon';
 import humanTime from 'flarum/helpers/humanTime';
 import { truncate } from 'flarum/utils/string';
 import Button from 'flarum/components/Button';
+import ScheduleDraftModal from './ScheduleDraftModal';
 
 export default class DraftsList extends Component {
     init() {
@@ -56,8 +57,18 @@ export default class DraftsList extends Component {
                                                     icon: 'fas fa-times',
                                                     style: 'float: right; z-index: 20;',
                                                     className: 'Button Button--icon Button--link draft--delete',
-                                                    title: app.translator.trans('fof-drafts.forum.dropdown.button'),
+                                                    title: app.translator.trans('fof-drafts.forum.dropdown.delete_button'),
                                                     onclick: this.deleteDraft.bind(this, draft),
+                                                })}
+                                                {Button.component({
+                                                    icon: draft.scheduledFor() ? 'fas fa-calendar-check' : 'fas fa-calendar-plus',
+                                                    style: 'float: right; z-index: 20;',
+                                                    className: 'Button Button--icon Button--link draft--schedule',
+                                                    title: app.translator.trans('fof-drafts.forum.dropdown.schedule_button'),
+                                                    onclick: e => {
+                                                        this.scheduleDraft(draft);
+                                                        e.stopPropagation();
+                                                    },
                                                 })}
                                                 <div className="Notification-excerpt">{truncate(draft.content(), 200)}</div>
                                             </a>
@@ -89,6 +100,10 @@ export default class DraftsList extends Component {
         app.composer.hide();
 
         this.loading = false;
+    }
+
+    scheduleDraft(draft) {
+        app.modal.show(new ScheduleDraftModal({draft}));
     }
 
     showComposer(draft) {

--- a/js/src/forum/components/ScheduleDraftModal.js
+++ b/js/src/forum/components/ScheduleDraftModal.js
@@ -31,6 +31,11 @@ export default class ScheduleDraftModal extends Modal {
                     {app.translator.trans('fof-drafts.forum.schedule_draft_modal.scheduled_text', {datetime: dayjs(this.props.draft.scheduledFor()).format('LLLL')})}
                 </Alert>
             </div> : '',
+            this.props.draft.scheduledValidationError() ? <div className="Modal-alert">
+                <Alert type="error" dismissible={false}>
+                    {app.translator.trans('fof-drafts.forum.schedule_draft_modal.scheduled_error', { error: this.props.draft.scheduledValidationError() })}
+                </Alert>
+            </div> : '',
             <input style="display: none"></input>,
             <div className="Modal-body">
                 <div className="Form Form--centered">
@@ -96,7 +101,7 @@ export default class ScheduleDraftModal extends Modal {
 
         this.props.draft
             .save(
-                { scheduledFor: (this.unscheduleMode() ? null : this.scheduledFor()) }
+                { scheduledFor: (this.unscheduleMode() ? null : this.scheduledFor()), clearValidationError: true, scheduledValidationError: '' }
             )
             .then(() => (this.success = true))
             .catch(() => { })

--- a/js/src/forum/components/ScheduleDraftModal.js
+++ b/js/src/forum/components/ScheduleDraftModal.js
@@ -1,0 +1,92 @@
+import Alert from 'flarum/components/Alert';
+import Button from 'flarum/components/Button';
+import Modal from 'flarum/components/Modal';
+
+import flatpickr from "flatpickr";
+import * as dayjs from 'dayjs';
+import * as localizedFormat from 'dayjs/plugin/localizedFormat';
+
+dayjs.extend(localizedFormat);
+
+export default class ScheduleDraftModal extends Modal {
+    init() {
+        super.init();
+
+        this.loading = false;
+    }
+
+    className() {
+        return 'ScheduleDraftModal';
+    }
+
+    title() {
+        return app.translator.trans('fof-drafts.forum.schedule_draft_modal.title');
+    }
+
+    content() {
+        return [
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css"></link>,
+            this.props.draft.scheduledFor() ? <div className="Modal-alert">
+                <Alert type="success" dismissible={false}>
+                    {app.translator.trans('fof-drafts.forum.schedule_draft_modal.scheduled_text', {datetime: dayjs(this.props.draft.scheduledFor()).format('LLLL')})}
+                </Alert>
+            </div> : '',
+            <input style="display: none"></input>,
+            <div className="Modal-body">
+                <div className="Form Form--centered">
+                    <p className="helpText">{app.translator.trans('fof-drafts.forum.schedule_draft_modal.text')}</p>
+                    <div className="Form-group flatpickr">
+                        <input
+                            name="scheduledFor"
+                            className="FormControl flatpickr-input"
+                            data-input
+                        />
+                    </div>
+                    <div className="Form-group">
+                        {Button.component({
+                            className: 'Button Button--primary Button--block',
+                            type: 'submit',
+                            loading: this.loading,
+                            children: app.translator.trans('fof-drafts.forum.schedule_draft_modal.submit_button'),
+                        })}
+                    </div>
+                </div>
+            </div>
+        ];
+    }
+
+    config(isInitialized) {
+        if (isInitialized) return;
+
+        this.flatpickr = flatpickr('.flatpickr-input', {
+            enableTime: true,
+            enableSeconds: false,
+            minDate: Date.now(),
+            maxDate: new Date(9999, 12, 31),
+            defaultDate: this.props.draft.scheduledFor()
+        });
+    }
+
+    onsubmit(e) {
+        e.preventDefault();
+
+        const scheduledFor = new Date(document.getElementsByName("scheduledFor")[0].value);
+
+        // If the user hasn't actually entered a different email address, we don't
+        // need to do anything. Woot!
+        if (scheduledFor.getTime() === this.props.draft.scheduledFor().getTime()) {
+            m.redraw();
+            return;
+        }
+
+        this.loading = true;
+
+        this.props.draft
+            .save(
+                { scheduledFor }
+            )
+            .then(() => (this.success = true))
+            .catch(() => { })
+            .then(this.loaded.bind(this));
+    }
+}

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -67,7 +67,7 @@ app.initializers.add('fof-drafts', () => {
                         delete this.component.draft.data.attributes.relationships;
 
                         this.component.draft
-                            .save(this.component.data())
+                            .save(Object.assign(this.component.draft.data.attributes, this.component.data()))
                             .then(draft => {
                                 app.cache.drafts = app.cache.drafts || [];
                                 app.cache.drafts.forEach((cacheDraft, i) => {

--- a/js/src/forum/models/Draft.js
+++ b/js/src/forum/models/Draft.js
@@ -16,5 +16,6 @@ export default class Draft extends mixin(Model, {
     content: Model.attribute('content'),
     title: Model.attribute('title'),
     relationships: Model.attribute('relationships'),
+    scheduledFor: Model.attribute('scheduledFor', Model.transformDate),
     updatedAt: Model.attribute('updatedAt', Model.transformDate),
 }) {}

--- a/js/src/forum/models/Draft.js
+++ b/js/src/forum/models/Draft.js
@@ -15,6 +15,7 @@ export default class Draft extends mixin(Model, {
     user: Model.hasOne('user'),
     content: Model.attribute('content'),
     title: Model.attribute('title'),
+    scheduledValidationError: Model.attribute('scheduledValidationError'),
     relationships: Model.attribute('relationships'),
     scheduledFor: Model.attribute('scheduledFor', Model.transformDate),
     updatedAt: Model.attribute('updatedAt', Model.transformDate),

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,1 +1,3 @@
-module.exports = require('flarum-webpack-config')();
+module.exports = require('flarum-webpack-config')({
+    useExtensions: ['fof-components']
+});

--- a/migrations/2019_08_04_151000_change_content_to_medium_text.php
+++ b/migrations/2019_08_04_151000_change_content_to_medium_text.php
@@ -18,4 +18,9 @@ return [
             $table->mediumText('content')->change();
         });
     },
+    'down'   => function (Builder $schema) {
+        $schema->table('drafts', function (Blueprint $table) {
+            $table->string('content')->change();
+        });
+    },
 ];

--- a/migrations/2020_05_24_000000_add_scheduled_at_column.php
+++ b/migrations/2020_05_24_000000_add_scheduled_at_column.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) 2020 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('drafts', [
+    'scheduled_for' => ['dateTime', 'nullable' => true],
+]);

--- a/migrations/2020_05_24_000000_add_scheduled_at_column.php
+++ b/migrations/2020_05_24_000000_add_scheduled_at_column.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/drafts.
  *
- * Copyright (c) 2020 FriendsOfFlarum.
+ * Copyright (c) 2019 FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE.md
  * file that was distributed with this source code.

--- a/migrations/2020_05_24_000001_add_schedule_post_permission.php
+++ b/migrations/2020_05_24_000001_add_schedule_post_permission.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) 2020 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+use Flarum\Group\Group;
+
+return Migration::addPermissions([
+    'user.scheduleDrafts' => Group::MODERATOR_ID,
+]);

--- a/migrations/2020_05_24_000001_add_schedule_post_permission.php
+++ b/migrations/2020_05_24_000001_add_schedule_post_permission.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/drafts.
  *
- * Copyright (c) 2020 FriendsOfFlarum.
+ * Copyright (c) 2019 FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE.md
  * file that was distributed with this source code.

--- a/migrations/2020_05_24_000002_add_error_and_ip_columns.php
+++ b/migrations/2020_05_24_000002_add_error_and_ip_columns.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/drafts.
  *
- * Copyright (c) 2020 FriendsOfFlarum.
+ * Copyright (c) 2019 FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE.md
  * file that was distributed with this source code.
@@ -13,5 +13,5 @@ use Flarum\Database\Migration;
 
 return Migration::addColumns('drafts', [
     'scheduled_validation_error' => ['mediumText', 'nullable' => true],
-    'ip_address' => ['string', 'length' => 45, 'nullable' => true]
+    'ip_address'                 => ['string', 'length' => 45, 'nullable' => true]
 ]);

--- a/migrations/2020_05_24_000002_add_error_and_ip_columns.php
+++ b/migrations/2020_05_24_000002_add_error_and_ip_columns.php
@@ -13,5 +13,5 @@ use Flarum\Database\Migration;
 
 return Migration::addColumns('drafts', [
     'scheduled_validation_error' => ['mediumText', 'nullable' => true],
-    'ip_address'                 => ['string', 'length' => 45, 'nullable' => true]
+    'ip_address'                 => ['string', 'length' => 45, 'nullable' => true],
 ]);

--- a/migrations/2020_05_24_000002_add_error_and_ip_columns.php
+++ b/migrations/2020_05_24_000002_add_error_and_ip_columns.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) 2020 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('drafts', [
+    'scheduled_validation_error' => ['mediumText', 'nullable' => true],
+    'ip_address' => ['string', 'length' => 45, 'nullable' => true]
+]);

--- a/migrations/2020_05_24_000003_add_scheduled_post_setting.php
+++ b/migrations/2020_05_24_000003_add_scheduled_post_setting.php
@@ -12,5 +12,5 @@
 use Flarum\Database\Migration;
 
 return Migration::addSettings([
-    'fof-drafts.enable_scheduled_drafts' => true
+    'fof-drafts.enable_scheduled_drafts' => true,
 ]);

--- a/migrations/2020_05_24_000003_add_scheduled_post_setting.php
+++ b/migrations/2020_05_24_000003_add_scheduled_post_setting.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) 2019 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addSettings([
+    'fof-drafts.enable_scheduled_drafts' => true
+]);

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -8,3 +8,7 @@
   left: unset;
   right: 42px;
 }
+
+.scheduledValidationError {
+  color: @control-danger-color;
+}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -19,6 +19,7 @@ fof-drafts:
       title: Schedule Draft
       text: Schedule your draft to automatically post at a later time!
       scheduled_text: Scheduled to post on {datetime}.
+      scheduled_error: "Unable to post because: {error}."
       unschedule_button: Unschedule
       reschedule_button: Reschedule
       schedule_button: Schedule

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -3,6 +3,11 @@ fof-drafts:
     permissions:
       start: Create drafts
       schedule: Schedule drafts
+    settings:
+      title: Drafts Settings
+      enable_scheduled_drafts: Enable Scheduled Drafts
+  console:
+    scheduled_drafts_disabled: Scheduled drafts are currently disabled in settings.
   forum:
     composer:
       title: Save Draft

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -18,4 +18,6 @@ fof-drafts:
       title: Schedule Draft
       text: Schedule your draft ahead of time!
       scheduled_text: Scheduled to post on {datetime}.
-      submit_button: Schedule!
+      unschedule_button: Unschedule!
+      reschedule_button: Reschedule!
+      schedule_button: Schedule!

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,7 +1,8 @@
 fof-drafts:
   admin:
     permissions:
-      start: Create discussion drafts
+      start: Create drafts
+      schedule: Schedule drafts
   forum:
     composer:
       title: Save Draft

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -14,3 +14,8 @@ fof-drafts:
       button: Delete Draft
       tooltip: => fof-drafts.forum.dropdown.title
       alert: Are you sure you want to delete your draft?
+    schedule_draft_modal:
+      title: Schedule Draft
+      text: Schedule your draft ahead of time!
+      scheduled_text: Scheduled to post on {datetime}.
+      submit_button: Schedule!

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -16,8 +16,8 @@ fof-drafts:
       alert: Are you sure you want to delete your draft?
     schedule_draft_modal:
       title: Schedule Draft
-      text: Schedule your draft ahead of time!
+      text: Schedule your draft to automatically post at a later time!
       scheduled_text: Scheduled to post on {datetime}.
-      unschedule_button: Unschedule!
-      reschedule_button: Reschedule!
-      schedule_button: Schedule!
+      unschedule_button: Unschedule
+      reschedule_button: Reschedule
+      schedule_button: Schedule

--- a/src/Api/Controller/CreateDraftController.php
+++ b/src/Api/Controller/CreateDraftController.php
@@ -15,6 +15,7 @@ use Flarum\Api\Controller\AbstractCreateController;
 use FoF\Drafts\Api\Serializer\DraftSerializer;
 use FoF\Drafts\Command\CreateDraft;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -52,9 +53,10 @@ class CreateDraftController extends AbstractCreateController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $actor = $request->getAttribute('actor');
+        $ipAddress = Arr::get($request->getServerParams(), 'REMOTE_ADDR', '127.0.0.1');
 
         return $this->bus->dispatch(
-            new CreateDraft($actor, array_get($request->getParsedBody(), 'data', []))
+            new CreateDraft($actor, array_get($request->getParsedBody(), 'data', []), $ipAddress)
         );
     }
 }

--- a/src/Api/Controller/UpdateDraftController.php
+++ b/src/Api/Controller/UpdateDraftController.php
@@ -15,6 +15,7 @@ use Flarum\Api\Controller\AbstractShowController;
 use FoF\Drafts\Api\Serializer\DraftSerializer;
 use FoF\Drafts\Command\UpdateDraft;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -40,8 +41,10 @@ class UpdateDraftController extends AbstractShowController
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
+        $ipAddress = Arr::get($request->getServerParams(), 'REMOTE_ADDR', '127.0.0.1');
+
         return $this->bus->dispatch(
-            new UpdateDraft(array_get($request->getQueryParams(), 'id'), $request->getAttribute('actor'), array_get($request->getParsedBody(), 'data', []))
+            new UpdateDraft(array_get($request->getQueryParams(), 'id'), $request->getAttribute('actor'), array_get($request->getParsedBody(), 'data', []), $ipAddress)
         );
     }
 }

--- a/src/Api/Serializer/DraftSerializer.php
+++ b/src/Api/Serializer/DraftSerializer.php
@@ -30,6 +30,7 @@ class DraftSerializer extends AbstractSerializer
             'title'         => $draft->title,
             'content'       => $draft->content,
             'relationships' => json_decode($draft->relationships),
+            'scheduledValidationError' => $draft->scheduled_validation_error,
             'scheduledFor'     => $this->formatDate($draft->scheduled_for),
             'updatedAt'     => $this->formatDate($draft->updated_at),
         ];

--- a/src/Api/Serializer/DraftSerializer.php
+++ b/src/Api/Serializer/DraftSerializer.php
@@ -30,6 +30,7 @@ class DraftSerializer extends AbstractSerializer
             'title'         => $draft->title,
             'content'       => $draft->content,
             'relationships' => json_decode($draft->relationships),
+            'scheduledFor'     => $this->formatDate($draft->scheduled_for),
             'updatedAt'     => $this->formatDate($draft->updated_at),
         ];
     }

--- a/src/Api/Serializer/DraftSerializer.php
+++ b/src/Api/Serializer/DraftSerializer.php
@@ -27,12 +27,12 @@ class DraftSerializer extends AbstractSerializer
     protected function getDefaultAttributes($draft)
     {
         return [
-            'title'         => $draft->title,
-            'content'       => $draft->content,
-            'relationships' => json_decode($draft->relationships),
+            'title'                    => $draft->title,
+            'content'                  => $draft->content,
+            'relationships'            => json_decode($draft->relationships),
             'scheduledValidationError' => $draft->scheduled_validation_error,
-            'scheduledFor'     => $this->formatDate($draft->scheduled_for),
-            'updatedAt'     => $this->formatDate($draft->updated_at),
+            'scheduledFor'             => $this->formatDate($draft->scheduled_for),
+            'updatedAt'                => $this->formatDate($draft->updated_at),
         ];
     }
 

--- a/src/Command/CreateDraft.php
+++ b/src/Command/CreateDraft.php
@@ -30,14 +30,20 @@ class CreateDraft
     public $data;
 
     /**
+     * The IP address of the draft's creator.
+     */
+    public $ipAddress;
+
+    /**
      * CreateDraft constructor.
      *
      * @param User  $actor
      * @param array $data
      */
-    public function __construct(User $actor, array $data)
+    public function __construct(User $actor, array $data, string $ipAddress)
     {
         $this->actor = $actor;
         $this->data = $data;
+        $this->ipAddress = $ipAddress;
     }
 }

--- a/src/Command/CreateDraftHandler.php
+++ b/src/Command/CreateDraftHandler.php
@@ -39,6 +39,7 @@ class CreateDraftHandler
         $draft->title = isset($data['attributes']['title']) ? $data['attributes']['title'] : '';
         $draft->content = isset($data['attributes']['content']) ? $data['attributes']['content'] : '';
         $draft->relationships = isset($data['relationships']) ? json_encode($data['relationships']) : json_encode('');
+        $draft->scheduled_for = isset($data['attributes']['scheduledFor']) ? Carbon::parse($data['attributes']['scheduledFor']) : null;
         $draft->updated_at = Carbon::now();
 
         $draft->save();

--- a/src/Command/CreateDraftHandler.php
+++ b/src/Command/CreateDraftHandler.php
@@ -41,6 +41,11 @@ class CreateDraftHandler
         $draft->relationships = isset($data['relationships']) ? json_encode($data['relationships']) : json_encode('');
         $draft->scheduled_for = isset($data['attributes']['scheduledFor']) && $actor->can('user.scheduleDrafts') ? Carbon::parse($data['attributes']['scheduledFor']) : null;
         $draft->updated_at = Carbon::now();
+        $draft->ip_address = $command->ipAddress;
+
+        if (array_key_exists('clearValidationError', $data['attributes'])) {
+            $draft->scheduled_validation_error = '';
+        }
 
         $draft->save();
 

--- a/src/Command/CreateDraftHandler.php
+++ b/src/Command/CreateDraftHandler.php
@@ -39,7 +39,7 @@ class CreateDraftHandler
         $draft->title = isset($data['attributes']['title']) ? $data['attributes']['title'] : '';
         $draft->content = isset($data['attributes']['content']) ? $data['attributes']['content'] : '';
         $draft->relationships = isset($data['relationships']) ? json_encode($data['relationships']) : json_encode('');
-        $draft->scheduled_for = isset($data['attributes']['scheduledFor']) ? Carbon::parse($data['attributes']['scheduledFor']) : null;
+        $draft->scheduled_for = isset($data['attributes']['scheduledFor']) && $actor->can('user.scheduleDrafts') ? Carbon::parse($data['attributes']['scheduledFor']) : null;
         $draft->updated_at = Carbon::now();
 
         $draft->save();

--- a/src/Command/UpdateDraft.php
+++ b/src/Command/UpdateDraft.php
@@ -37,16 +37,22 @@ class UpdateDraft
     public $data;
 
     /**
+     * The IP address of the draft's creator.
+     */
+    public $ipAddress;
+
+    /**
      * UpdateDraft constructor.
      *
      * @param $draftId
      * @param User  $actor
      * @param array $data
      */
-    public function __construct($draftId, User $actor, array $data)
+    public function __construct($draftId, User $actor, array $data, string $ipAddress)
     {
         $this->draftId = $draftId;
         $this->actor = $actor;
         $this->data = $data;
+        $this->ipAddress = $ipAddress;
     }
 }

--- a/src/Command/UpdateDraftHandler.php
+++ b/src/Command/UpdateDraftHandler.php
@@ -52,7 +52,12 @@ class UpdateDraftHandler
             $draft->relationships =  json_encode($data['relationships']);
         }
 
+        if (array_key_exists('clearValidationError', $data['attributes'])) {
+            $draft->scheduled_validation_error = '';
+        }
+
         $draft->scheduled_for = isset($data['attributes']['scheduledFor']) && $actor->can('user.scheduleDrafts') ? Carbon::parse($data['attributes']['scheduledFor']) : null;
+        $draft->ip_address = $command->ipAddress;
         $draft->updated_at = Carbon::now();
 
         $draft->save();

--- a/src/Command/UpdateDraftHandler.php
+++ b/src/Command/UpdateDraftHandler.php
@@ -41,7 +41,7 @@ class UpdateDraftHandler
         $this->assertCan($actor, 'user.saveDrafts');
 
         if (isset($data['attributes']['title'])) {
-            $draft->title =  $data['attributes']['title'];
+            $draft->title = $data['attributes']['title'];
         }
 
         if (isset($data['attributes']['content'])) {
@@ -49,7 +49,7 @@ class UpdateDraftHandler
         }
 
         if (isset($data['relationships'])) {
-            $draft->relationships =  json_encode($data['relationships']);
+            $draft->relationships = json_encode($data['relationships']);
         }
 
         if (array_key_exists('clearValidationError', $data['attributes'])) {

--- a/src/Command/UpdateDraftHandler.php
+++ b/src/Command/UpdateDraftHandler.php
@@ -52,10 +52,7 @@ class UpdateDraftHandler
             $draft->relationships =  json_encode($data['relationships']);
         }
 
-        if (isset($data['attributes']['scheduledFor'])) {
-            $draft->scheduled_for = Carbon::parse($data['attributes']['scheduledFor']);
-        }
-
+        $draft->scheduled_for = isset($data['attributes']['scheduledFor']) ? Carbon::parse($data['attributes']['scheduledFor']) : null;
         $draft->updated_at = Carbon::now();
 
         $draft->save();

--- a/src/Command/UpdateDraftHandler.php
+++ b/src/Command/UpdateDraftHandler.php
@@ -52,7 +52,7 @@ class UpdateDraftHandler
             $draft->relationships =  json_encode($data['relationships']);
         }
 
-        $draft->scheduled_for = isset($data['attributes']['scheduledFor']) ? Carbon::parse($data['attributes']['scheduledFor']) : null;
+        $draft->scheduled_for = isset($data['attributes']['scheduledFor']) && $actor->can('user.scheduleDrafts') ? Carbon::parse($data['attributes']['scheduledFor']) : null;
         $draft->updated_at = Carbon::now();
 
         $draft->save();

--- a/src/Command/UpdateDraftHandler.php
+++ b/src/Command/UpdateDraftHandler.php
@@ -37,11 +37,25 @@ class UpdateDraftHandler
         if ($actor->id !== $draft->user_id) {
             throw new PermissionDeniedException();
         }
+
         $this->assertCan($actor, 'user.saveDrafts');
 
-        $draft->title = isset($data['attributes']['title']) ? $data['attributes']['title'] : '';
-        $draft->content = isset($data['attributes']['content']) ? $data['attributes']['content'] : '';
-        $draft->relationships = isset($data['relationships']) ? json_encode($data['relationships']) : json_encode('');
+        if (isset($data['attributes']['title'])) {
+            $draft->title =  $data['attributes']['title'];
+        }
+
+        if (isset($data['attributes']['content'])) {
+            $draft->content = $data['attributes']['content'];
+        }
+
+        if (isset($data['relationships'])) {
+            $draft->relationships =  json_encode($data['relationships']);
+        }
+
+        if (isset($data['attributes']['scheduledFor'])) {
+            $draft->scheduled_for = Carbon::parse($data['attributes']['scheduledFor']);
+        }
+
         $draft->updated_at = Carbon::now();
 
         $draft->save();

--- a/src/Console/PublishDrafts.php
+++ b/src/Console/PublishDrafts.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) 2020 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Fof\Drafts\Console;
+
+use Carbon\Carbon;
+use Flarum\Console\AbstractCommand;
+use Flarum\Discussion\Command\StartDiscussion;
+use Flarum\Foundation\ValidationException;
+use Flarum\Post\Command\PostReply;
+use Flarum\User\User;
+use FoF\Drafts\Draft;
+use Illuminate\Contracts\Bus\Dispatcher;
+
+class PublishDrafts extends AbstractCommand
+{
+    protected $bus;
+
+    public function __construct(Dispatcher $bus)
+    {
+        parent::__construct();
+        $this->bus = $bus;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('drafts:publish')
+            ->setDescription('Publish all scheduled drafts.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function fire()
+    {
+        $this->info('Starting...');
+
+        foreach (Draft::where('scheduled_for', '<=', Carbon::now())->with('user')->get() as $draft) {
+            try {
+                $relationships = json_decode($draft->relationships, true);
+                $ip = '172.0.0.1';
+
+                if (array_key_exists('discussion', $relationships)) {
+                    $post = $this->bus->dispatch(
+                        new PostReply($relationships['discussion']['id'], $draft->user, ['attributes' => ['content' => $draft->content]], $ip)
+                    );
+                    $post->created_at = $draft->scheduled_for;
+                    $post->save();
+                } else {
+                    $discussion = $this->bus->dispatch(
+                        new StartDiscussion($draft->user, [
+                            'attributes' => [
+                                'title' => $draft->title,
+                                'content' => $draft->content,
+                            ],
+                            'relationships' => $relationships
+                        ], $ip)
+                    );
+                    $discussion->created_at = $draft->scheduled_for;
+                    $discussion->firstPost->created_at = $draft->scheduled_for;
+                    $discussion->save();
+                    $discussion->firstPost->save();
+                }
+                $draft->delete();
+            } catch (ValidationException $e) {
+                $draft->scheduled_validation_error = $e->getMessage();
+                $draft->save();
+                echo $e->getMessage();
+            }
+        }
+    }
+}

--- a/src/Console/PublishDrafts.php
+++ b/src/Console/PublishDrafts.php
@@ -49,11 +49,14 @@ class PublishDrafts extends AbstractCommand
         foreach (Draft::where('scheduled_for', '<=', Carbon::now())->with('user')->get() as $draft) {
             try {
                 $relationships = json_decode($draft->relationships, true);
-                $ip = '172.0.0.1';
 
                 if (array_key_exists('discussion', $relationships)) {
                     $post = $this->bus->dispatch(
-                        new PostReply($relationships['discussion']['id'], $draft->user, ['attributes' => ['content' => $draft->content]], $ip)
+                        new PostReply($relationships['discussion']['id'], $draft->user, [
+                            'attributes' => [
+                                'content' => $draft->content
+                            ]
+                        ], $draft->ip_address)
                     );
                     $post->created_at = $draft->scheduled_for;
                     $post->save();
@@ -65,7 +68,7 @@ class PublishDrafts extends AbstractCommand
                                 'content' => $draft->content,
                             ],
                             'relationships' => $relationships,
-                        ], $ip)
+                        ], $draft->ip_address)
                     );
                     $discussion->created_at = $draft->scheduled_for;
                     $discussion->firstPost->created_at = $draft->scheduled_for;

--- a/src/Console/PublishDrafts.php
+++ b/src/Console/PublishDrafts.php
@@ -54,6 +54,7 @@ class PublishDrafts extends AbstractCommand
 
         if (!$this->settings->get('fof-drafts.enable_scheduled_drafts')) {
             $this->error($this->translator->trans('fof-drafts.console.scheduled_drafts_disabled'));
+
             return;
         }
 
@@ -65,8 +66,8 @@ class PublishDrafts extends AbstractCommand
                     $post = $this->bus->dispatch(
                         new PostReply($relationships['discussion']['id'], $draft->user, [
                             'attributes' => [
-                                'content' => $draft->content
-                            ]
+                                'content' => $draft->content,
+                            ],
                         ], $draft->ip_address)
                     );
                     $post->created_at = $draft->scheduled_for;

--- a/src/Console/PublishDrafts.php
+++ b/src/Console/PublishDrafts.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/drafts.
  *
- * Copyright (c) 2020 FriendsOfFlarum.
+ * Copyright (c) 2019 FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE.md
  * file that was distributed with this source code.
@@ -16,7 +16,6 @@ use Flarum\Console\AbstractCommand;
 use Flarum\Discussion\Command\StartDiscussion;
 use Flarum\Foundation\ValidationException;
 use Flarum\Post\Command\PostReply;
-use Flarum\User\User;
 use FoF\Drafts\Draft;
 use Illuminate\Contracts\Bus\Dispatcher;
 
@@ -29,6 +28,7 @@ class PublishDrafts extends AbstractCommand
         parent::__construct();
         $this->bus = $bus;
     }
+
     /**
      * {@inheritdoc}
      */
@@ -61,10 +61,10 @@ class PublishDrafts extends AbstractCommand
                     $discussion = $this->bus->dispatch(
                         new StartDiscussion($draft->user, [
                             'attributes' => [
-                                'title' => $draft->title,
+                                'title'   => $draft->title,
                                 'content' => $draft->content,
                             ],
-                            'relationships' => $relationships
+                            'relationships' => $relationships,
                         ], $ip)
                     );
                     $discussion->created_at = $draft->scheduled_for;

--- a/src/Draft.php
+++ b/src/Draft.php
@@ -22,7 +22,7 @@ class Draft extends AbstractModel
     /**
      * {@inheritdoc}
      */
-    protected $dates = ['updated_at'];
+    protected $dates = ['updated_at', 'scheduled_for'];
 
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/src/Listeners/AddApiAttributes.php
+++ b/src/Listeners/AddApiAttributes.php
@@ -36,6 +36,7 @@ class AddApiAttributes
     {
         if ($event->isSerializer(ForumSerializer::class)) {
             $event->attributes['canSaveDrafts'] = $event->actor->hasPermissionLike('user.saveDrafts');
+            $event->attributes['canScheduleDrafts'] = $event->actor->hasPermissionLike('user.scheduleDrafts');
         }
 
         if ($event->isSerializer(CurrentUserSerializer::class)) {

--- a/src/Listeners/AddSettings.php
+++ b/src/Listeners/AddSettings.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
-* This file is part of fof/drafts.
-*
-* Copyright (c) 2019 FriendsOfFlarum.
-*
-* For the full copyright and license information, please view the LICENSE.md
-* file that was distributed with this source code.
-*/
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) 2019 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
 
 namespace FoF\Drafts\Listeners;
 

--- a/src/Listeners/AddSettings.php
+++ b/src/Listeners/AddSettings.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+* This file is part of fof/drafts.
+*
+* Copyright (c) 2019 FriendsOfFlarum.
+*
+* For the full copyright and license information, please view the LICENSE.md
+* file that was distributed with this source code.
+*/
+
 namespace FoF\Drafts\Listeners;
 
 use Flarum\Api\Event\Serializing;

--- a/src/Listeners/AddSettings.php
+++ b/src/Listeners/AddSettings.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace FoF\Drafts\Listeners;
+
+use Flarum\Api\Event\Serializing;
+use Flarum\Api\Serializer\ForumSerializer;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class AddSettings
+{
+    protected $settings;
+
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Serializing::class, [$this, 'attachSettings']);
+    }
+
+    public function attachSettings(Serializing $event)
+    {
+        if ($event->isSerializer(ForumSerializer::class)) {
+            $event->attributes['drafts.enableScheduledDrafts'] = (bool) $this->settings->get('fof-drafts.enable_scheduled_drafts');
+        }
+    }
+}

--- a/src/Providers/ConsoleProvider.php
+++ b/src/Providers/ConsoleProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/drafts.
  *
- * Copyright (c) 2020 FriendsOfFlarum.
+ * Copyright (c) 2019 FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE.md
  * file that was distributed with this source code.

--- a/src/Providers/ConsoleProvider.php
+++ b/src/Providers/ConsoleProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) 2020 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Fof\Drafts\Providers;
+
+use Flarum\Foundation\AbstractServiceProvider;
+use Illuminate\Console\Scheduling\Schedule;
+
+class ConsoleProvider extends AbstractServiceProvider
+{
+    public function register()
+    {
+        if (!defined('ARTISAN_BINARY')) {
+            define('ARTISAN_BINARY', 'flarum');
+        }
+
+        $this->app->resolving(Schedule::class, function (Schedule $schedule) {
+            $schedule->command('drafts:publish')
+                ->everyMinute()
+                ->withoutOverlapping()
+                ->appendOutputTo(storage_path('logs/drafts-publish.log'));
+        });
+    }
+}


### PR DESCRIPTION
- Users can schedule a draft to be posted at a later date
- Cron command or laravel scheduler will post all drafts. Supports reply, discussion, and private discussion (at least)
- Controlled by a permission
- Posting is run through the command bus, so extensions aren;t broken.

Questions for Reviewers:
- Should there be an admin setting to disable scheduled drafts>