### PR TITLE
Bugfixes

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -45,7 +45,7 @@ app.initializers.add('fof-drafts', () => {
         const getData = (field) => (field === 'content' ? this.component.editor.value() : data[field]) || '';
 
         for (const field of fields) {
-            if ((!draft && getData(field)) || getData(field) != draft.data.attributes[field]) {
+            if ((!draft && getData(field)) || (draft && getData(field) != draft.data.attributes[field])) {
                 return true;
             }
         }

--- a/js/src/forum/models/Draft.js
+++ b/js/src/forum/models/Draft.js
@@ -28,7 +28,11 @@ export default class Draft extends mixin(Model, {
         const relationships = this.loadRelationships();
         if ('discussion' in relationships) {
             return 'reply';
-        } else if (app.initializers.has('fof-byobu') && ('recipientGroups' in relationships || 'recipientUsers' in relationships)) {
+        } else if (
+            flarum.extensions['fof-byobu'] &&
+            flarum.extensions['fof-byobu'].components && // If private discussion composer is not exported, we can't support PM drafts.
+            ('recipientGroups' in relationships || 'recipientUsers' in relationships)
+        ) {
             return 'privateDiscussion';
         } else {
             return 'discussion';


### PR DESCRIPTION
`if ((!draft && getData(field)) || getData(field) != draft.data.attributes[field])` is problematic: The reason it was in an if, else is because if there is no draft, the second part should not even be considered.  Needs to be `draft && getData(field) != draft.data.attributes[field])`

Don't classify drafts as private discussions if byobu is not exporting the private discussion composer. This removes this extension's dependency on a given Byobu version.