### PR TITLE
Add deepEqual utility function for comparing

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -25,6 +25,7 @@ import ComposerState from 'flarum/forum/states/ComposerState';
 import fillRelationship from './utils/fillRelationship';
 import DraftsListState from './states/DraftsListState';
 import app from 'flarum/forum/app';
+import deepEqual from './utils/deepEqual';
 
 export * from './components';
 export * from './models';
@@ -61,7 +62,10 @@ app.initializers.add('fof-drafts', () => {
     const getData = (field) => (field === 'content' ? this.fields.content() : data[field]) || '';
 
     for (const field of fields) {
-      if ((!draft && getData(field)) || (draft && getData(field) != draft.data.attributes[field])) {
+      const fieldValue = getData(field);
+      const draftFieldValue = draft && draft.data.attributes[field];
+
+      if ((!draft && fieldValue) || (draft && !deepEqual(fieldValue, draftFieldValue))) {
         return true;
       }
     }

--- a/js/src/forum/utils/deepEqual.js
+++ b/js/src/forum/utils/deepEqual.js
@@ -1,0 +1,20 @@
+// Deep comparison function
+export default function deepEqual(obj1, obj2) {
+  if (obj1 === obj2) {
+    return true;
+  }
+  if (typeof obj1 !== 'object' || typeof obj2 !== 'object' || obj1 == null || obj2 == null) {
+    return false;
+  }
+  let keys1 = Object.keys(obj1);
+  let keys2 = Object.keys(obj2);
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+  for (let key of keys1) {
+    if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
Add deepEqual utility function for comparing. This makes it possible to have an object in extra fields of a draft and avoid triggering an auto-save all the time.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
