### PR TITLE
chore: update icons to avoid clashing, add haptics support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
             "title": "FoF Drafts",
             "category": "feature",
             "icon": {
-                "name": "fas fa-edit",
+                "name": "fas fa-feather-pointed",
                 "backgroundColor": "#e74c3c",
                 "color": "#fff"
             },

--- a/js/src/admin/extend.ts
+++ b/js/src/admin/extend.ts
@@ -20,7 +20,7 @@ export default [
     }))
     .permission(
       () => ({
-        icon: 'fas fa-edit',
+        icon: 'fas fa-pen-to-square',
         label: app.translator.trans('fof-drafts.admin.permissions.start'),
         permission: 'user.saveDrafts',
       }),

--- a/js/src/forum/addComposerIntegration.tsx
+++ b/js/src/forum/addComposerIntegration.tsx
@@ -3,9 +3,9 @@ import Stream from 'flarum/common/utils/Stream';
 import Button from 'flarum/common/components/Button';
 import ComposerState from 'flarum/forum/states/ComposerState';
 import app from 'flarum/forum/app';
+import haptic from 'flarum/common/utils/haptic';
 import deepEqual from './utils/deepEqual';
 import fillRelationship from './utils/fillRelationship';
-import PrivateDiscussionComposer from 'ext:fof/byobu/forum/pages/discussions/PrivateDiscussionComposer';
 
 export default function () {
   // Add changed() method to ComposerState
@@ -212,13 +212,16 @@ export default function () {
     items.add(
       'save-draft',
       <Button
-        icon={this.state.justSaved ? 'fas fa-check' : this.state.saving ? 'fas fa-spinner fa-spin' : 'fas fa-save'}
+        icon={this.state.justSaved ? 'fas fa-check' : this.state.saving ? 'fas fa-spinner fa-spin' : 'fas fa-floppy-disk'}
         className={classNames.join(' ')}
         itemClassName="App-backControl"
         title={app.translator.trans('fof-drafts.forum.composer.title')}
         aria-label={app.translator.trans('fof-drafts.forum.composer.title')}
         disabled={this.state.saving || this.state.justSaved || this.loading}
-        onclick={this.state.saveDraft.bind(this.state)}
+        onclick={() => {
+          haptic('success');
+          this.state.saveDraft();
+        }}
       />,
       20
     );

--- a/js/src/forum/components/DraftsDropdown.tsx
+++ b/js/src/forum/components/DraftsDropdown.tsx
@@ -8,7 +8,7 @@ export default class DraftsDropdown extends HeaderDropdown {
   static initAttrs(attrs: any) {
     attrs.className = classList('DraftsDropdown', attrs.className);
     attrs.label = attrs.label || app.translator.trans('fof-drafts.forum.dropdown.tooltip');
-    attrs.icon = attrs.icon || 'fas fa-edit';
+    attrs.icon = attrs.icon || 'fas fa-feather-pointed';
 
     super.initAttrs(attrs);
   }

--- a/js/src/forum/components/DraftsList.tsx
+++ b/js/src/forum/components/DraftsList.tsx
@@ -1,4 +1,5 @@
 import app from 'flarum/forum/app';
+import haptic from 'flarum/common/utils/haptic';
 import Component from 'flarum/common/Component';
 import HeaderList from 'flarum/forum/components/HeaderList';
 import Button from 'flarum/common/components/Button';
@@ -24,6 +25,7 @@ export default class DraftsList extends Component<DraftsListAttrs> {
   deleteAll() {
     if (!confirm(app.translator.trans('fof-drafts.forum.dropdown.delete_all_alert') as string)) return;
 
+    haptic('heavy');
     app
       .request({
         method: 'DELETE',
@@ -45,7 +47,7 @@ export default class DraftsList extends Component<DraftsListAttrs> {
       <Tooltip showOnFocus={false} text={app.translator.trans('fof-drafts.forum.dropdown.delete_all_button')}>
         <Button
           data-container="body"
-          icon="fas fa-trash-alt"
+          icon="fas fa-trash-can"
           className="Button Button--link Button--icon Alert-dismiss"
           onclick={this.deleteAll.bind(this)}
         />

--- a/js/src/forum/components/DraftsListItem.tsx
+++ b/js/src/forum/components/DraftsListItem.tsx
@@ -1,4 +1,5 @@
 import app from 'flarum/forum/app';
+import haptic from 'flarum/common/utils/haptic';
 import Component from 'flarum/common/Component';
 import Avatar from 'flarum/common/components/Avatar';
 import Icon from 'flarum/common/components/Icon';
@@ -44,7 +45,7 @@ export default class DraftsListItem extends Component<IAttrs> {
     const { draft, state } = this.attrs;
 
     let scheduledDraftIcon = 'far fa-calendar-plus';
-    if (draft.scheduledValidationError()) scheduledDraftIcon = 'far fa-calendar-times';
+    if (draft.scheduledValidationError()) scheduledDraftIcon = 'far fa-calendar-xmark';
     else if (draft.scheduledFor()) scheduledDraftIcon = 'far fa-calendar-check';
 
     // Build the content with scheduled icon if needed
@@ -86,9 +87,10 @@ export default class DraftsListItem extends Component<IAttrs> {
       <>
         <Tooltip showOnFocus={false} text={app.translator.trans('fof-drafts.forum.dropdown.delete_button')}>
           <Button
-            icon="fas fa-trash-alt"
+            icon="fas fa-trash-can"
             className="Button Button--link hasIcon draft--delete"
             onclick={(e: MouseEvent) => {
+              haptic('heavy');
               state.deleteDraft(draft);
               e.stopPropagation();
             }}
@@ -101,6 +103,7 @@ export default class DraftsListItem extends Component<IAttrs> {
               icon={scheduledDraftIcon}
               className="Button Button--link hasIcon draft--schedule"
               onclick={(e: MouseEvent) => {
+                haptic('medium');
                 state.scheduleDraft(draft);
                 e.stopPropagation();
               }}

--- a/js/src/forum/models/Draft.ts
+++ b/js/src/forum/models/Draft.ts
@@ -59,7 +59,7 @@ export default class Draft extends Model {
   icon(): string {
     switch (this.type()) {
       case 'discussion':
-        return 'fas fa-edit';
+        return 'fas fa-feather-pointed';
       case 'reply':
         return 'fas fa-reply';
       case 'privateDiscussion':


### PR DESCRIPTION
JS is expected to fail until `2.0.0-beta.8` due to the haptics