### PR TITLE
[2.x] fix: guard against scheduling discussion drafts with no title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ js/node_modules
 vendor/
 composer.lock
 .phpunit.result.cache
+tests/.phpunit.cache/
+.claude/

--- a/js/src/forum/components/ScheduleDraftModal.tsx
+++ b/js/src/forum/components/ScheduleDraftModal.tsx
@@ -15,6 +15,7 @@ interface ScheduleDraftModalAttrs extends IFormModalAttrs {
 
 export default class ScheduleDraftModal extends FormModal<ScheduleDraftModalAttrs> {
   loading: boolean = false;
+  titleError: boolean = false;
   date!: string;
   time!: string;
   previewFormatString!: string;
@@ -59,6 +60,15 @@ export default class ScheduleDraftModal extends FormModal<ScheduleDraftModalAttr
             {app.translator.trans('fof-drafts.forum.schedule_draft_modal.scheduled_error', {
               error: this.attrs.draft.scheduledValidationError(),
             })}
+          </Alert>
+        </div>
+      ) : (
+        ''
+      ),
+      this.titleError ? (
+        <div className="Modal-alert">
+          <Alert type="error" dismissible={false}>
+            {app.translator.trans('fof-drafts.forum.schedule_draft_modal.no_title_error')}
           </Alert>
         </div>
       ) : (
@@ -171,6 +181,13 @@ export default class ScheduleDraftModal extends FormModal<ScheduleDraftModalAttr
 
   onsubmit(e: Event) {
     e.preventDefault();
+
+    if (this.attrs.draft.type() !== 'reply' && !this.attrs.draft.title()?.trim()) {
+      this.titleError = true;
+      m.redraw();
+      return;
+    }
+    this.titleError = false;
 
     this.loading = true;
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -10,6 +10,7 @@ fof-drafts:
       schedule_log_output: Append scheduler output to log storage
   console:
     scheduled_drafts_disabled: Scheduled drafts are currently disabled in settings.
+    no_title_error: "Draft skipped: discussion title is missing."
   ref:
     schedule_draft: Schedule draft
   forum:
@@ -44,6 +45,7 @@ fof-drafts:
       # String passed to dayjs.format() to generate the preview
       schedule_time_preview_formatter: LLLL
       schedule_time_preview_invalid: Invalid date and/or time
+      no_title_error: A discussion title is required before scheduling.
     user:
       settings:
         drafts_heading: Drafts

--- a/src/Console/PublishDrafts.php
+++ b/src/Console/PublishDrafts.php
@@ -83,6 +83,13 @@ class PublishDrafts extends AbstractCommand
                     $post->ip_address = $draft->ip_address;
                     $post->save();
                 } else {
+                    if (empty(trim((string) $draft->title))) {
+                        $draft->scheduled_validation_error = $this->translator->trans('fof-drafts.console.no_title_error');
+                        $draft->save();
+                        $this->error("Draft {$draft->id} skipped: discussion title is missing.");
+                        continue;
+                    }
+
                     $this->info('Publishing draft discussion');
 
                     // Create a new discussion using JsonApi

--- a/tests/integration/console/PublishDraftsReplyTest.php
+++ b/tests/integration/console/PublishDraftsReplyTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Drafts\Tests\integration\console;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Tests that reply drafts bypass the discussion title guard from issue #118.
+ *
+ * A reply draft has a discussion relationship and does not need a title.
+ * The command should publish the reply and delete the draft.
+ */
+class PublishDraftsReplyTest extends ConsoleTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const PAST = '2020-01-01 00:00:00';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-drafts');
+
+        $this->setting('fof-drafts.enable_scheduled_drafts', '1');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+            'discussions' => [
+                [
+                    'id'         => 1,
+                    'title'      => 'Test Discussion',
+                    'user_id'    => 2,
+                    'created_at' => self::PAST,
+                    'slug'       => 'test-discussion',
+                    'is_private' => 0,
+                ],
+            ],
+            'drafts' => [
+                [
+                    'id'                         => 1,
+                    'user_id'                    => 2,
+                    'content'                    => 'Test reply content',
+                    'title'                      => null,
+                    'relationships'              => json_encode(['discussion' => ['data' => ['id' => '1']]]),
+                    'extra'                      => '{}',
+                    'scheduled_for'              => self::PAST,
+                    'updated_at'                 => self::PAST,
+                    'ip_address'                 => '127.0.0.1',
+                    'scheduled_validation_error' => '',
+                ],
+            ],
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function reply_draft_with_no_title_is_not_skipped_by_title_guard(): void
+    {
+        $this->runCommand(['command' => 'drafts:publish']);
+
+        $this->assertNull(
+            $this->database()->table('drafts')->where('id', 1)->first(),
+            'Reply draft should be deleted after publishing'
+        );
+    }
+}

--- a/tests/integration/console/PublishDraftsTest.php
+++ b/tests/integration/console/PublishDraftsTest.php
@@ -26,7 +26,7 @@ class PublishDraftsTest extends ConsoleTestCase
 {
     use RetrievesAuthorizedUsers;
 
-    private const PAST   = '2020-01-01 00:00:00';
+    private const PAST = '2020-01-01 00:00:00';
     private const FUTURE = '2099-01-01 00:00:00';
 
     protected function setUp(): void

--- a/tests/integration/console/PublishDraftsTest.php
+++ b/tests/integration/console/PublishDraftsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of fof/drafts.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Drafts\Tests\integration\console;
+
+use Flarum\Testing\integration\ConsoleTestCase;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Tests for the discussion draft title guard added in issue #118.
+ *
+ * Seeds three past-due discussion drafts with invalid titles (null, empty, whitespace)
+ * plus one future-scheduled draft. No reply drafts are present so the command
+ * does not attempt any API calls.
+ */
+class PublishDraftsTest extends ConsoleTestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const PAST   = '2020-01-01 00:00:00';
+    private const FUTURE = '2099-01-01 00:00:00';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-drafts');
+
+        $this->setting('fof-drafts.enable_scheduled_drafts', '1');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+            'drafts' => [
+                // ID 1 — null title (past due)
+                $this->discussionDraft(['id' => 1, 'title' => null, 'scheduled_for' => self::PAST]),
+                // ID 2 — empty string title (past due)
+                $this->discussionDraft(['id' => 2, 'title' => '', 'scheduled_for' => self::PAST]),
+                // ID 3 — whitespace-only title (past due)
+                $this->discussionDraft(['id' => 3, 'title' => '   ', 'scheduled_for' => self::PAST]),
+                // ID 4 — null title, future (must not be processed)
+                $this->discussionDraft(['id' => 4, 'title' => null, 'scheduled_for' => self::FUTURE]),
+            ],
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function discussionDraft(array $overrides = []): array
+    {
+        return array_merge([
+            'user_id'                    => 2,
+            'content'                    => 'Test content',
+            'title'                      => null,
+            'relationships'              => '{}',
+            'extra'                      => '{}',
+            'scheduled_for'              => self::PAST,
+            'updated_at'                 => self::PAST,
+            'ip_address'                 => '127.0.0.1',
+            'scheduled_validation_error' => '',
+        ], $overrides);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function command_returns_message_when_scheduled_drafts_disabled(): void
+    {
+        $this->setting('fof-drafts.enable_scheduled_drafts', '0');
+
+        $output = $this->runCommand(['command' => 'drafts:publish']);
+
+        $this->assertStringContainsString('disabled', $output);
+    }
+
+    #[Test]
+    public function discussion_draft_with_null_title_is_skipped(): void
+    {
+        $this->runCommand(['command' => 'drafts:publish']);
+
+        $draft = $this->database()->table('drafts')->where('id', 1)->first();
+        $this->assertEquals('fof-drafts.console.no_title_error', $draft->scheduled_validation_error);
+        $this->assertNotNull($draft->scheduled_for, 'Skipped draft should not be deleted');
+    }
+
+    #[Test]
+    public function discussion_draft_with_empty_string_title_is_skipped(): void
+    {
+        $this->runCommand(['command' => 'drafts:publish']);
+
+        $draft = $this->database()->table('drafts')->where('id', 2)->first();
+        $this->assertEquals('fof-drafts.console.no_title_error', $draft->scheduled_validation_error);
+    }
+
+    #[Test]
+    public function discussion_draft_with_whitespace_only_title_is_skipped(): void
+    {
+        $this->runCommand(['command' => 'drafts:publish']);
+
+        $draft = $this->database()->table('drafts')->where('id', 3)->first();
+        $this->assertEquals('fof-drafts.console.no_title_error', $draft->scheduled_validation_error);
+    }
+
+    #[Test]
+    public function draft_scheduled_in_future_is_not_processed(): void
+    {
+        $this->runCommand(['command' => 'drafts:publish']);
+
+        $draft = $this->database()->table('drafts')->where('id', 4)->first();
+        $this->assertNotNull($draft, 'Future draft should not be processed');
+        $this->assertEmpty($draft->scheduled_validation_error);
+    }
+}

--- a/tests/integration/forum/ForumTest.php
+++ b/tests/integration/forum/ForumTest.php
@@ -12,6 +12,7 @@
 namespace FoF\Drafts\Tests\integration\forum;
 
 use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ForumTest extends TestCase
 {
@@ -22,10 +23,8 @@ class ForumTest extends TestCase
         $this->extension('fof-drafts');
     }
 
-    /**
-     * @test
-     */
-    public function extension_boots_and_serializes()
+    #[Test]
+    public function extension_boots_and_serializes(): void
     {
         $response = $this->send($this->request('GET', '/'));
 

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,25 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="true"
-    stopOnFailure="false"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">../src/</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Flarum Integration Tests">
-            <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" backupGlobals="false" colors="true" processIsolation="true" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Flarum Integration Tests">
+      <directory suffix="Test.php">./integration</directory>
+      <exclude>./integration/tmp</exclude>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,27 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">../src/</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Flarum Unit Tests">
-            <directory suffix="Test.php">./unit</directory>
-        </testsuite>
-    </testsuites>
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
-    </listeners>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Flarum Unit Tests">
+      <directory suffix="Test.php">./unit</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../src/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
## Problem

Scheduling a discussion draft with no title would silently fail when the `drafts:publish` command ran. The command passed a `null` title to `DiscussionResource`, which threw a `ValidationException` with a cryptic error message. The draft would then be stuck — not published, with an unhelpful error saved to `scheduled_validation_error`.

Fixes #118.

## Changes

### Frontend — `ScheduleDraftModal`
- Validates the draft title before submitting. If the title is blank and the draft is not a reply, shows an inline error alert and blocks the API call.
- Reply drafts are unaffected — they don't require a title.

### Backend — `PublishDrafts` console command
- Adds an explicit title check in the discussion-draft branch. Drafts with a missing/blank title are skipped, a clear localised error is saved to `scheduled_validation_error`, and the command continues to the next draft.
- This handles any drafts that were scheduled before the frontend guard was in place.

### Locale — `en.yml`
- `fof-drafts.console.no_title_error` — message recorded on the draft by the command.
- `fof-drafts.forum.schedule_draft_modal.no_title_error` — inline error shown in the schedule modal.

### Tests
- `PublishDraftsTest` — integration tests for the console command: null/empty/whitespace titles are skipped with the correct error; future-scheduled drafts are not processed; disabled setting returns the right message.
- `PublishDraftsReplyTest` — confirms reply drafts bypass the title guard and are published successfully.
- PHPUnit config updated to PHPUnit 11 (`#[Test]` attributes, updated schema, removed deprecated XML options).

## Test plan
- [ ] Discussion draft, no title → open schedule modal → submit → inline error, no draft saved as scheduled
- [ ] Discussion draft, has title → schedules normally
- [ ] Reply draft, no title → schedules normally
- [ ] Existing scheduled discussion draft with no title → `drafts:publish` skips it, records `no_title_error`, draft survives with error visible in UI
- [ ] `composer test` passes (7 tests, 11 assertions, no deprecations)
- [ ] `composer analyse:phpstan` clean