### PR TITLE
[2.x] Fix tooltip not disappearing on some browsers

### DIFF
--- a/js/src/forum/components/DraftsList.tsx
+++ b/js/src/forum/components/DraftsList.tsx
@@ -22,7 +22,8 @@ export default class DraftsList extends Component<DraftsListAttrs> {
     });
   }
 
-  deleteAll() {
+  deleteAll(e) {
+    $(e.currentTarget).trigger('mouseleave');
     if (!confirm(app.translator.trans('fof-drafts.forum.dropdown.delete_all_alert') as string)) return;
 
     haptic('heavy');

--- a/js/src/forum/components/DraftsList.tsx
+++ b/js/src/forum/components/DraftsList.tsx
@@ -22,7 +22,7 @@ export default class DraftsList extends Component<DraftsListAttrs> {
     });
   }
 
-  deleteAll(e) {
+  deleteAll(e: MouseEvent) {
     $(e.currentTarget).trigger('mouseleave');
     if (!confirm(app.translator.trans('fof-drafts.forum.dropdown.delete_all_alert') as string)) return;
 
@@ -50,7 +50,9 @@ export default class DraftsList extends Component<DraftsListAttrs> {
           data-container="body"
           icon="fas fa-trash-can"
           className="Button Button--link Button--icon Alert-dismiss"
-          onclick={this.deleteAll.bind(this)}
+          onclick={(e: MouseEvent) => {
+            this.deleteAll(e);
+          }}
         />
       </Tooltip>
     );

--- a/js/src/forum/components/DraftsList.tsx
+++ b/js/src/forum/components/DraftsList.tsx
@@ -23,7 +23,7 @@ export default class DraftsList extends Component<DraftsListAttrs> {
   }
 
   deleteAll(e: MouseEvent) {
-    $(e.currentTarget).trigger('mouseleave');
+    $(e.currentTarget as HTMLElement).trigger('mouseleave');
     if (!confirm(app.translator.trans('fof-drafts.forum.dropdown.delete_all_alert') as string)) return;
 
     haptic('heavy');

--- a/js/src/forum/components/DraftsListItem.tsx
+++ b/js/src/forum/components/DraftsListItem.tsx
@@ -90,6 +90,7 @@ export default class DraftsListItem extends Component<IAttrs> {
             icon="fas fa-trash-can"
             className="Button Button--link hasIcon draft--delete"
             onclick={(e: MouseEvent) => {
+              $(e.currentTarget).trigger('mouseleave');
               haptic('heavy');
               state.deleteDraft(draft);
               e.stopPropagation();
@@ -103,6 +104,7 @@ export default class DraftsListItem extends Component<IAttrs> {
               icon={scheduledDraftIcon}
               className="Button Button--link hasIcon draft--schedule"
               onclick={(e: MouseEvent) => {
+                $(e.currentTarget).trigger('mouseleave');
                 haptic('medium');
                 state.scheduleDraft(draft);
                 e.stopPropagation();

--- a/js/src/forum/components/DraftsListItem.tsx
+++ b/js/src/forum/components/DraftsListItem.tsx
@@ -90,7 +90,7 @@ export default class DraftsListItem extends Component<IAttrs> {
             icon="fas fa-trash-can"
             className="Button Button--link hasIcon draft--delete"
             onclick={(e: MouseEvent) => {
-              $(e.currentTarget).trigger('mouseleave');
+              $(e.currentTarget as HTMLElement).trigger('mouseleave');
               haptic('heavy');
               state.deleteDraft(draft);
               e.stopPropagation();
@@ -104,7 +104,7 @@ export default class DraftsListItem extends Component<IAttrs> {
               icon={scheduledDraftIcon}
               className="Button Button--link hasIcon draft--schedule"
               onclick={(e: MouseEvent) => {
-                $(e.currentTarget).trigger('mouseleave');
+                $(e.currentTarget as HTMLElement).trigger('mouseleave');
                 haptic('medium');
                 state.scheduleDraft(draft);
                 e.stopPropagation();


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
As title, fixed the delete all drafts tooltip not disappearing on some specific browsers. I saw there was one previous fix on this but it could still be reproduced in specific situations. Likely slightly older chromic (not out of date), OperaGX, and some Safari.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
If there's a better way to implement this, please tell me.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
