### PR TITLE
fix: correct draft counter increment and dropdown crash

### DIFF
--- a/js/src/forum/addComposerIntegration.tsx
+++ b/js/src/forum/addComposerIntegration.tsx
@@ -5,6 +5,7 @@ import ComposerState from 'flarum/forum/states/ComposerState';
 import app from 'flarum/forum/app';
 import haptic from 'flarum/common/utils/haptic';
 import deepEqual from './utils/deepEqual';
+import { adjustDraftCount } from './utils/draftCount';
 import fillRelationship from './utils/fillRelationship';
 
 export default function () {
@@ -274,7 +275,10 @@ export default function () {
       !draft.content() &&
       confirm(app.translator.trans('fof-drafts.forum.composer.discard_empty_draft_alert') as string)
     ) {
-      draft.delete();
+      draft.delete().then(() => {
+        adjustDraftCount(-1);
+        m.redraw();
+      });
     }
 
     return prevented;
@@ -305,7 +309,10 @@ export default function () {
   // Delete drafts when submitted
   function deleteDraftsOnSubmit(this: any): void {
     if (this.composer.draft) {
-      this.composer.draft.delete();
+      this.composer.draft.delete().then(() => {
+        adjustDraftCount(-1);
+        m.redraw();
+      });
     }
   }
 

--- a/js/src/forum/components/DraftsDropdown.tsx
+++ b/js/src/forum/components/DraftsDropdown.tsx
@@ -26,7 +26,7 @@ export default class DraftsDropdown extends HeaderDropdown {
       return app.store.all('drafts').length;
     }
 
-    return app.store.all('drafts').length + (app.session.user?.draftCount() || 0);
+    return app.session.user?.draftCount() || 0;
   }
 
   getNewCount(): number {

--- a/js/src/forum/components/DraftsList.tsx
+++ b/js/src/forum/components/DraftsList.tsx
@@ -7,6 +7,7 @@ import Tooltip from 'flarum/common/components/Tooltip';
 import ItemList from 'flarum/common/utils/ItemList';
 import type Draft from '../models/Draft';
 import type DraftsListState from '../states/DraftsListState';
+import { setDraftCount } from '../utils/draftCount';
 import DraftsListItem from './DraftsListItem';
 
 interface DraftsListAttrs {
@@ -35,6 +36,7 @@ export default class DraftsList extends Component<DraftsListAttrs> {
         // Clear drafts from store
         const drafts = app.store.all<Draft>('drafts');
         drafts.forEach((draft) => app.store.remove(draft));
+        setDraftCount(0);
         m.redraw();
       });
   }
@@ -72,7 +74,7 @@ export default class DraftsList extends Component<DraftsListAttrs> {
       >
         <ul className="HeaderListGroup-content">
           {drafts
-            .sort((a, b) => b.updatedAt()!.getTime() - a.updatedAt()!.getTime())
+            .sort((a, b) => (b.updatedAt()?.getTime?.() ?? 0) - (a.updatedAt()?.getTime?.() ?? 0))
             .map((draftItem) => {
               return <DraftsListItem draft={draftItem} state={state} />;
             })}

--- a/js/src/forum/states/DraftsListState.ts
+++ b/js/src/forum/states/DraftsListState.ts
@@ -1,5 +1,6 @@
 import app from 'flarum/forum/app';
 import type Draft from '../models/Draft';
+import { adjustDraftCount, setDraftCount } from '../utils/draftCount';
 
 export default class DraftsListState {
   loading: boolean = false;
@@ -11,6 +12,8 @@ export default class DraftsListState {
     this.loading = true;
 
     draft.delete().then(() => {
+      adjustDraftCount(-1);
+
       if (app.composer.body && app.composer.draft && app.composer.draft.id() === draft.id() && !app.composer.changed?.()) {
         app.composer.hide();
       }
@@ -81,7 +84,10 @@ export default class DraftsListState {
     app.store
       .find<Draft[]>('drafts')
       .then(
-        () => (app.cache.draftsLoaded = true),
+        () => {
+          app.cache.draftsLoaded = true;
+          setDraftCount(app.store.all<Draft>('drafts').length);
+        },
         () => {}
       )
       .then(() => {

--- a/js/src/forum/utils/draftCount.ts
+++ b/js/src/forum/utils/draftCount.ts
@@ -1,0 +1,23 @@
+import app from 'flarum/forum/app';
+
+function normalizedDraftCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+export function getDraftCount(): number {
+  return normalizedDraftCount(app.session.user?.draftCount?.());
+}
+
+export function setDraftCount(count: number): void {
+  const user = app.session.user as any;
+
+  if (!user?.data?.attributes) {
+    return;
+  }
+
+  user.data.attributes.draftCount = normalizedDraftCount(count);
+}
+
+export function adjustDraftCount(delta: number): void {
+  setDraftCount(getDraftCount() + delta);
+}

--- a/src/Api/Resource/DraftResource.php
+++ b/src/Api/Resource/DraftResource.php
@@ -89,6 +89,8 @@ class DraftResource extends Resource\AbstractDatabaseResource
                 ->writable()
                 ->minLength(1)
                 ->maxLength(65535),
+            Schema\DateTime::make('updatedAt')
+                ->nullable(),
             Schema\Arr::make('extra')
                 ->nullable()
                 ->writable(),
@@ -98,6 +100,8 @@ class DraftResource extends Resource\AbstractDatabaseResource
             Schema\DateTime::make('scheduledFor')
                 ->nullable()
                 ->writable(fn (Draft $draft, Context $context) => $context->getActor()->can('user.scheduleDrafts')),
+            Schema\Str::make('scheduledValidationError')
+                ->nullable(),
             Schema\Boolean::make('clearValidationError')
                 ->writable()
                 ->set(function (Draft $draft, bool $value) {


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #123**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- Fix draft counter incrementing by 2 on first save. `getUnreadCount()` was summing `app.store.all('drafts').length` with `user.draftCount()`. Since the Create endpoint uses `->defaultInclude(['user'])`, the API response already updates `draftCount` on the user model, and the new record also appears in the store — both sides increment, producing +2. Fixed by using `draftCount()` alone before drafts are loaded, and `store.length` after.
- Fix `TypeError: Cannot read properties of undefined (reading 'getTime')` crash when opening the drafts dropdown with 2+ drafts. `updatedAt` was not declared in `DraftResource::fields()`, so it was never serialized. Added it to the API resource and guarded the sort comparator with optional chaining.
- Add `draftCount` utility (`getDraftCount`, `setDraftCount`, `adjustDraftCount`) for consistent client-side count management. The Delete endpoint does not include the user in its response, so `adjustDraftCount(-1)` is called on delete, discard, submit, and bulk-delete paths to keep the counter accurate.
- Expose `scheduledValidationError` in `DraftResource` — the model and UI already reference it but it was missing from the API fields.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![PixPin_2026-04-06_02-51-58](https://github.com/user-attachments/assets/0e5d5be8-a139-4eb9-b7ea-c51587cd052c)


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
