### PR TITLE
[2.x] fix: save draft button hidden on mobile; /drafts page blank

### DIFF
--- a/js/src/forum/addComposerIntegration.tsx
+++ b/js/src/forum/addComposerIntegration.tsx
@@ -196,7 +196,7 @@ export default function () {
     if (
       !(this.state.bodyMatches('flarum/forum/components/DiscussionComposer') || this.state.bodyMatches('flarum/forum/components/ReplyComposer')) ||
       !app.forum.attribute('canSaveDrafts') ||
-      this.state.position === 'minimized'
+      (this.state.position === 'minimized' && !this.state.isFullScreen())
     )
       return;
 

--- a/js/src/forum/components/DraftsListItem.tsx
+++ b/js/src/forum/components/DraftsListItem.tsx
@@ -61,7 +61,7 @@ export default class DraftsListItem extends Component<IAttrs> {
             <Icon name="far fa-clock" className="draft--scheduledIcon" />
           </Tooltip>
         )}
-        {draft.type() === 'reply' ? draft.loadRelationships().discussion.title() : draft.title()}
+        {draft.type() === 'reply' ? (draft.loadRelationships().discussion?.title() ?? draft.title()) : draft.title()}
       </>
     );
 

--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -4,7 +4,7 @@ import Draft from './models/Draft';
 
 export default [
   new Extend.Routes() //
-    .add('drafts', '/drafts', () => import('./components/DraftsPage').then((module) => module.default)),
+    .add('drafts', '/drafts', () => import('./components/DraftsPage')),
 
   new Extend.Store() //
     .add('drafts', Draft),


### PR DESCRIPTION
## Summary

**Fix 1: Save draft button missing on mobile (#128)**

On mobile, `ComposerState.Position.MINIMIZED` is the active fullscreen composing state — `isFullScreen()` returns `true` when `app.screen() === 'phone'`. The previous guard unconditionally hid the save draft button when minimized, making it inaccessible on mobile. Now the button is hidden only when minimized on non-phone screens, matching how core's own `Composer.js` decides which controls to show.

**Fix 2: /drafts page renders blank**

The route was registered as `() => import('./DraftsPage').then(m => m.default)`. `DefaultResolver.onmatch()` calls `(await fn()).default` — it expects the function to resolve to the **module**, then accesses `.default` itself. By pre-extracting `.default`, `onmatch` received the class and tried `.default` on it, getting `undefined`. Mithril mounted nothing — blank `#content`, no JS errors. Fix: pass the raw import, consistent with how core registers async routes (e.g. `/notifications`).

**Fix 3: Guard against missing discussion on /drafts page**

On the `/drafts` page, reply drafts resolve their `discussion` relationship via `app.store.getById()` — if the discussion isn't already in the store (e.g. fresh page load), `loadRelationships().discussion` is `undefined` and `.title()` throws. Falls back to `draft.title()` when the discussion model isn't available.

Closes #128