### PR TITLE
fix: correct async route registration for /drafts page

### DIFF
--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -4,7 +4,7 @@ import Draft from './models/Draft';
 
 export default [
   new Extend.Routes() //
-    .add('drafts', '/drafts', () => import('./components/DraftsPage').then((module) => module.default)),
+    .add('drafts', '/drafts', () => import('./components/DraftsPage')),
 
   new Extend.Store() //
     .add('drafts', Draft),


### PR DESCRIPTION
The `/drafts` route was registered as:

\`\`\`ts
() => import('./components/DraftsPage').then((module) => module.default)
\`\`\`

`DefaultResolver.onmatch()` calls `(await fn()).default` — it expects the function to resolve to the **module**, then accesses `.default` itself. By pre-extracting `.default` in the arrow function, `onmatch` received the class and tried to access `.default` on it, getting `undefined`. Mithril then mounted nothing, leaving `#content` blank with no JS errors.

Fix: pass the raw import promise, consistent with how core registers its own async routes (e.g. `/notifications`).

Closes #128