### PR TITLE
[2.x] fix: remove the save draft button when the composer is minimized on mobile

### DIFF
--- a/js/src/forum/addComposerIntegration.tsx
+++ b/js/src/forum/addComposerIntegration.tsx
@@ -196,7 +196,11 @@ export default function () {
     if (
       !(this.state.bodyMatches('flarum/forum/components/DiscussionComposer') || this.state.bodyMatches('flarum/forum/components/ReplyComposer')) ||
       !app.forum.attribute('canSaveDrafts') ||
-      (this.state.position === 'minimized' && !this.state.isFullScreen())
+      // Just position — isFullScreen() is unconditionally true on phones
+      // ("we always consider the composer as full-screen" — ComposerState),
+      // so qualifying with it meant the minimized composer kept its save
+      // button pinned in the mobile header.
+      this.state.position === 'minimized'
     )
       return;
 


### PR DESCRIPTION
## The bug

On mobile, the save-draft icon correctly appears in the header while the composer is open — but stays pinned there after minimizing the composer.

## Root cause

The control-item guard already tried to handle this:

```js
(this.state.position === 'minimized' && !this.state.isFullScreen())
```

But core's `ComposerState.isFullScreen()` is **unconditionally true on phones** — *"or if we are on a mobile device, where we always consider the composer as full-screen"*. So on mobile the second clause is always false, the guard can never fire, and the button — which carries `App-backControl`, the class core pins into the app header on phones — survives minimization. Desktop evaluates `isFullScreen()` as false when minimized, which is why only mobile misbehaved.

The subtlety only bites at the exact transition: while the composer is open, `position === 'minimized'` short-circuits the whole clause, so `isFullScreen()`'s phone behaviour never matters until the moment you minimize.

## The fix

The guard checks position alone. A composer cannot be minimized and full-screen at the same time, so the `!isFullScreen()` qualifier only ever served to defeat the check on phones.

## Verification

Reproduced on a real mobile-viewport session against a dev install before the fix (minimized composer, `item-save-draft` still rendered in `.Composer-controls`, fixed-positioned into the header), and confirmed fixed after — including manual on-device confirmation that the icon leaves the header on minimize and still appears while composing.