### PR TITLE
Remove question mark from enable draft autosave toggle label

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -49,7 +49,7 @@ fof-drafts:
     user:
       settings:
         drafts_heading: Drafts
-        draft_autosave_enable: Enable Draft Autosave?
+        draft_autosave_enable: Enable Draft Autosave
         draft_autosave_interval_label: Autosave Interval (seconds)
         draft_autosave_interval_button: Update Interval
         draft_autosave_interval_invalid: The interval must be an integer greater than 4.


### PR DESCRIPTION
Toggle settings anywhere should not be phrased as questions. Removed the question mark from "Enable Draft Autosave?" setting

**Changes proposed in this pull request:**
One key change to remove the question mark from the "Enable Draft Autosave?" setting

**Reviewers should focus on:**
-

**Screenshot**
<img width="486" height="150" alt="image" src="https://github.com/user-attachments/assets/8586cf2e-5e23-47d2-a8a4-048cde0f98b2" />

**Confirmed**
- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).