### PR TITLE
Fix autosave interval settings UI

### DIFF
--- a/js/src/forum/addPreferences.tsx
+++ b/js/src/forum/addPreferences.tsx
@@ -36,7 +36,7 @@ export default function () {
       items.add(
         'draft-autosave-interval',
         this.user.preferences().draftAutosaveEnable ? (
-          <label>
+          <label className="item-draft-autosave-interval">
             <p>{app.translator.trans('fof-drafts.forum.user.settings.draft_autosave_interval_label')}</p>
             <input className="FormControl" type="number" min="0" bidi={this.draftAutosaveInterval} />
             {Button.component(
@@ -51,6 +51,7 @@ export default function () {
                   } else {
                     this.draftAutosaveIntervalInvalid = false;
                     this.user.savePreferences({ draftAutosaveInterval: this.draftAutosaveInterval() }).then(() => {
+                      app.alerts.show({ type: 'success' }, app.translator.trans('fof-drafts.forum.user.settings.draft_autosave_interval_saved_message'));
                       m.redraw();
                     });
                   }

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -14,7 +14,7 @@
 }
 
 .item-draft-autosave-interval {
-  margin-top: 30px;
+  margin-top: 12px;
   input {
     width: 35%;
     display: inline-block;

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -53,6 +53,7 @@ fof-drafts:
         draft_autosave_interval_label: Autosave Interval (seconds)
         draft_autosave_interval_button: Update Interval
         draft_autosave_interval_invalid: The interval must be an integer greater than 4.
+        draft_autosave_interval_saved_message: Autosave interval was updated.
 
 fof-default-user-preferences:
   admin:


### PR DESCRIPTION
## Summary

Two small bugs in the «Autosave Interval» field under user Settings → Drafts:

- The wrapping `<label>` never had the `item-draft-autosave-interval` class applied, even though a matching LESS rule for it has existed since the field was introduced (#9). Without the class, the input renders full-width and the «Update Interval» button sits directly underneath it with no spacing, i.e. visually glued together. Also reduced that rule's `margin-top` from `30px` to `12px` — `30px` reads as an oversized gap between the toggle above and this field now that the rule is actually applied
- Clicking «Update Interval» saved the preference but gave no feedback at all. Added the standard `app.alerts.show({ type: 'success' }, ...)` success alert, matching the pattern used elsewhere (e.g. `AdminPage`, `UserSecurityPage`)

## Test plan

- [x] Built and manually verified on a live Flarum forum: enabled draft autosave, confirmed the interval field + button now render as a single joined control with normal spacing from the toggle above, and that saving a new interval shows a success alert

<img width="1005" height="215" alt="image" src="https://github.com/user-attachments/assets/65dbbd2d-11d8-4644-a03e-3be494bd434d" />

