### PR TITLE
[2.x] fix: handle null and missing relationship models safely

### DIFF
--- a/js/src/forum/addComposerIntegration.tsx
+++ b/js/src/forum/addComposerIntegration.tsx
@@ -69,13 +69,13 @@ export default function () {
         return false;
       }
 
-      const getId = (relItem: any): string => (typeof relItem.id == 'function' ? relItem.id() : relItem.id);
+      const getId = (relItem: any): string => (relItem ? (typeof relItem.id === 'function' ? relItem.id() : relItem.id) || '' : '');
 
       const dataIds = fillRelationship(composerData.relationships[relName], getId);
       const draftIds = fillRelationship(draftModel.relationships()[relName].data, getId);
 
-      const dataIdsArray = Array.isArray(dataIds) ? dataIds : [dataIds];
-      const draftIdsArray = Array.isArray(draftIds) ? draftIds : [draftIds];
+      const dataIdsArray: string[] = (Array.isArray(dataIds) ? dataIds : dataIds ? [dataIds] : []).filter(Boolean);
+      const draftIdsArray: string[] = (Array.isArray(draftIds) ? draftIds : draftIds ? [draftIds] : []).filter(Boolean);
 
       return !dataIdsArray.some((id: string, i: number) => id !== draftIdsArray[i]);
     };
@@ -134,10 +134,12 @@ export default function () {
           if (Array.isArray(relationship)) {
             // Convert array of models to JSON:API format with data wrapper
             serialized.relationships[relationshipKey] = {
-              data: relationship.map((relModel: any) => ({
-                type: typeof relModel.data?.type === 'function' ? relModel.data.type() : relModel.data?.type || relModel.type?.() || 'unknown',
-                id: typeof relModel.id === 'function' ? relModel.id() : relModel.id,
-              })),
+              data: relationship
+                .filter((relModel: any) => relModel && (typeof relModel.id === 'function' ? relModel.id() : relModel.id))
+                .map((relModel: any) => ({
+                  type: typeof relModel.data?.type === 'function' ? relModel.data.type() : relModel.data?.type || relModel.type?.() || 'unknown',
+                  id: typeof relModel.id === 'function' ? relModel.id() : relModel.id,
+                })),
             };
           } else if (relationship && typeof relationship === 'object') {
             // Convert single model to JSON:API format with data wrapper

--- a/js/src/forum/models/Draft.ts
+++ b/js/src/forum/models/Draft.ts
@@ -88,7 +88,9 @@ export default class Draft extends Model {
 
         if (!relationship || !relationship.data) return;
 
-        this.loadedRelationships![relationshipName] = fillRelationship(relationship.data, (model: any) => app.store.getById(model.type, model.id));
+        this.loadedRelationships![relationshipName] = fillRelationship(relationship.data, (model: any) =>
+          model && model.type && model.id ? app.store.getById(model.type, model.id) : null
+        );
       });
     }
 

--- a/js/src/forum/utils/fillRelationship.ts
+++ b/js/src/forum/utils/fillRelationship.ts
@@ -1,1 +1,7 @@
-export default <T, R>(items: T | T[], mapFn: (item: T) => R): R | R[] => (Array.isArray(items) ? items.map(mapFn).sort() : mapFn(items));
+export default <T, R>(items: T | T[] | null | undefined, mapFn: (item: T) => R): R[] | R | null => {
+  if (Array.isArray(items)) {
+    return (items.filter(Boolean) as T[]).map(mapFn).filter(Boolean).sort();
+  }
+
+  return items ? mapFn(items) : null;
+};


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #149**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Fixes an unhandled `TypeError: Cannot read properties of null (reading 'type')` that occurs when drafts contain `null` or deleted items in relationship arrays (e.g. `{"tags":{"data":[{"type":"tags","id":"12"},null]}}`).

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
