### PR TITLE
[1.x] fix: handle null and missing relationship models safely

### DIFF
--- a/js/src/forum/components/DraftsListItem.tsx
+++ b/js/src/forum/components/DraftsListItem.tsx
@@ -55,7 +55,7 @@ export default class DraftsListItem extends Component<IAttrs> {
                   {icon('far fa-clock', { className: 'draft--scheduledIcon' })}
                 </Tooltip>
               )}
-              {draft.type() === 'reply' ? draft.loadRelationships().discussion.title() : draft.title()}
+              {draft.type() === 'reply' ? draft.loadRelationships().discussion?.title() || draft.title() : draft.title()}
             </span>
             <span class="Notification-title-spring" />
             {humanTime(draft.updatedAt())}

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -89,12 +89,15 @@ app.initializers.add('fof-drafts', () => {
         return false;
       }
 
-      const getId = (element) => (typeof element.id == 'function' ? element.id() : element.id);
+      const getId = (element) => (element ? (typeof element.id == 'function' ? element.id() : element.id) || '' : '');
 
       const dataIds = fillRelationship(data.relationships[relationship], getId);
       const draftIds = fillRelationship(draft.relationships()[relationship].data, getId);
 
-      return !dataIds.some((id, i) => id !== draftIds[i]);
+      const dataIdsArray = (Array.isArray(dataIds) ? dataIds : dataIds ? [dataIds] : []).filter(Boolean);
+      const draftIdsArray = (Array.isArray(draftIds) ? draftIds : draftIds ? [draftIds] : []).filter(Boolean);
+
+      return !dataIdsArray.some((id, i) => id !== draftIdsArray[i]);
     };
 
     for (const relationship of relationships) {
@@ -133,11 +136,23 @@ app.initializers.add('fof-drafts', () => {
       return;
     }
 
+    const getCleanData = () => {
+      const data = this.data();
+      if (data && data.relationships) {
+        Object.keys(data.relationships).forEach((key) => {
+          if (Array.isArray(data.relationships[key])) {
+            data.relationships[key] = data.relationships[key].filter(Boolean);
+          }
+        });
+      }
+      return data;
+    };
+
     if (draft) {
       delete draft.data.attributes.relationships;
 
       draft
-        .save(Object.assign(draft.data.attributes, this.data()))
+        .save(Object.assign(draft.data.attributes, getCleanData()))
         .catch(() => {
           console.log('draft save failure ignored');
         })
@@ -145,7 +160,7 @@ app.initializers.add('fof-drafts', () => {
     } else {
       app.store
         .createRecord('drafts')
-        .save(this.data())
+        .save(getCleanData())
         .then((draft) => {
           draft.loadRelationships(true);
           this.draft = draft;

--- a/js/src/forum/models/Draft.js
+++ b/js/src/forum/models/Draft.js
@@ -74,7 +74,9 @@ export default class Draft extends mixin(Model, {
 
         if (!relationship || !relationship.data) return;
 
-        this.loadedRelationships[relationshipName] = fillRelationship(relationship.data, (model) => app.store.getById(model.type, model.id));
+        this.loadedRelationships[relationshipName] = fillRelationship(relationship.data, (model) =>
+          model && model.type && model.id ? app.store.getById(model.type, model.id) : null
+        );
       });
     }
 

--- a/js/src/forum/utils/fillRelationship.js
+++ b/js/src/forum/utils/fillRelationship.js
@@ -1,1 +1,7 @@
-export default (data, map) => (Array.isArray(data) ? data.map(map).sort() : map(data));
+export default (data, map) => {
+  if (Array.isArray(data)) {
+    return data.filter(Boolean).map(map).filter(Boolean).sort();
+  }
+
+  return data ? map(data) : null;
+};


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #149**
Backport fix from #150

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Backports the fix for an unhandled `TypeError: Cannot read properties of null (reading 'type')` that occurs when drafts contain `null` or deleted items in relationship arrays (e.g. `{"tags":{"data":[{"type":"tags","id":"12"},null]}}`).

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
